### PR TITLE
chore: update to @adobe/eslint-config-asset-compute 1.3.0 and fix issues

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019 Adobe Inc. All rights reserved.
+ * Copyright 2019 Adobe. All rights reserved.
  * This file is licensed to you under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License. You may obtain a copy
  * of the License at http://www.apache.org/licenses/LICENSE-2.0

--- a/package-lock.json
+++ b/package-lock.json
@@ -152,9 +152,9 @@
       }
     },
     "@adobe/eslint-config-asset-compute": {
-      "version": "1.2.0",
-      "resolved": "https://artifactory.corp.adobe.com:443/artifactory/api/npm/npmjs-remote/@adobe/eslint-config-asset-compute/-/eslint-config-asset-compute-1.2.0.tgz",
-      "integrity": "sha1-rZkhv7UP2rGQeGVCIQ84IInPC0s=",
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/@adobe/eslint-config-asset-compute/-/eslint-config-asset-compute-1.3.0.tgz",
+      "integrity": "sha512-Ks5y+EFKr8eF+tgViEni2oU8KVFMwM6TrcYijgYnsdUrMj7tM775OcrStwcGGbUz3hQDwo00GnOXV0iFaSFJlw==",
       "dev": true,
       "requires": {
         "eslint": "^6.8.0",
@@ -618,14 +618,14 @@
     },
     "acorn": {
       "version": "7.2.0",
-      "resolved": "https://artifactory.corp.adobe.com:443/artifactory/api/npm/npmjs-remote/acorn/-/acorn-7.2.0.tgz",
-      "integrity": "sha1-F+p+QNfIZA/1SmlMiJwm8xcE7/4=",
+      "resolved": "https://registry.npmjs.org/acorn/-/acorn-7.2.0.tgz",
+      "integrity": "sha512-apwXVmYVpQ34m/i71vrApRrRKCWQnZZF1+npOD0WV5xZFfwWOmKGQ2RWlfdy9vWITsenisM8M0Qeq8agcFHNiQ==",
       "dev": true
     },
     "acorn-jsx": {
       "version": "5.2.0",
-      "resolved": "https://artifactory.corp.adobe.com:443/artifactory/api/npm/npmjs-remote/acorn-jsx/-/acorn-jsx-5.2.0.tgz",
-      "integrity": "sha1-TGYGkXPW/daO2FI5/CViJhgrLr4=",
+      "resolved": "https://registry.npmjs.org/acorn-jsx/-/acorn-jsx-5.2.0.tgz",
+      "integrity": "sha512-HiUX/+K2YpkpJ+SzBffkM/AQ2YE03S0U1kjTLVpoJdhZMOWy8qvXVN9JdLqv2QsaQ6MPYQIuNmwD8zOiYUofLQ==",
       "dev": true
     },
     "ajv": {
@@ -641,7 +641,7 @@
     },
     "amazon-s3-uri": {
       "version": "0.0.3",
-      "resolved": "https://artifactory.corp.adobe.com:443/artifactory/api/npm/npmjs-remote/amazon-s3-uri/-/amazon-s3-uri-0.0.3.tgz",
+      "resolved": "https://registry.npmjs.org/amazon-s3-uri/-/amazon-s3-uri-0.0.3.tgz",
       "integrity": "sha1-3BiYANJfKQ6xNCqFdBudLJF1csE="
     },
     "ansi-escapes": {
@@ -664,7 +664,7 @@
     },
     "ansicolors": {
       "version": "0.3.2",
-      "resolved": "https://artifactory.corp.adobe.com:443/artifactory/api/npm/npmjs-remote/ansicolors/-/ansicolors-0.3.2.tgz",
+      "resolved": "https://registry.npmjs.org/ansicolors/-/ansicolors-0.3.2.tgz",
       "integrity": "sha1-ZlWX3oap/+Oqm/vmyuXG6kJrSXk="
     },
     "argparse": {
@@ -677,7 +677,7 @@
     },
     "arr-diff": {
       "version": "4.0.0",
-      "resolved": "https://artifactory.corp.adobe.com:443/artifactory/api/npm/npmjs-remote/arr-diff/-/arr-diff-4.0.0.tgz",
+      "resolved": "https://registry.npmjs.org/arr-diff/-/arr-diff-4.0.0.tgz",
       "integrity": "sha1-1kYQdP6/7HHn4VI1dhoyml3HxSA="
     },
     "arr-flatten": {
@@ -687,12 +687,12 @@
     },
     "arr-union": {
       "version": "3.1.0",
-      "resolved": "https://artifactory.corp.adobe.com:443/artifactory/api/npm/npmjs-remote/arr-union/-/arr-union-3.1.0.tgz",
+      "resolved": "https://registry.npmjs.org/arr-union/-/arr-union-3.1.0.tgz",
       "integrity": "sha1-45sJrqne+Gao8gbiiK9jkZuuOcQ="
     },
     "array-flatten": {
       "version": "1.1.1",
-      "resolved": "https://artifactory.corp.adobe.com:443/artifactory/api/npm/npmjs-remote/array-flatten/-/array-flatten-1.1.1.tgz",
+      "resolved": "https://registry.npmjs.org/array-flatten/-/array-flatten-1.1.1.tgz",
       "integrity": "sha1-ml9pkFGx5wczKPKgCJaLZOopVdI="
     },
     "array-union": {
@@ -703,7 +703,7 @@
     },
     "array-unique": {
       "version": "0.3.2",
-      "resolved": "https://artifactory.corp.adobe.com:443/artifactory/api/npm/npmjs-remote/array-unique/-/array-unique-0.3.2.tgz",
+      "resolved": "https://registry.npmjs.org/array-unique/-/array-unique-0.3.2.tgz",
       "integrity": "sha1-qJS3XUvE9s1nnvMkSp/Y9Gri1Cg="
     },
     "asn1": {
@@ -716,23 +716,23 @@
     },
     "assert-plus": {
       "version": "1.0.0",
-      "resolved": "https://artifactory.corp.adobe.com:443/artifactory/api/npm/npmjs-remote/assert-plus/-/assert-plus-1.0.0.tgz",
+      "resolved": "https://registry.npmjs.org/assert-plus/-/assert-plus-1.0.0.tgz",
       "integrity": "sha1-8S4PPF13sLHN2RRpQuTpbB5N1SU="
     },
     "assign-symbols": {
       "version": "1.0.0",
-      "resolved": "https://artifactory.corp.adobe.com:443/artifactory/api/npm/npmjs-remote/assign-symbols/-/assign-symbols-1.0.0.tgz",
+      "resolved": "https://registry.npmjs.org/assign-symbols/-/assign-symbols-1.0.0.tgz",
       "integrity": "sha1-WWZ/QfrdTyDMvCu5a41Pf3jsA2c="
     },
     "astral-regex": {
       "version": "1.0.0",
-      "resolved": "https://artifactory.corp.adobe.com:443/artifactory/api/npm/npmjs-remote/astral-regex/-/astral-regex-1.0.0.tgz",
-      "integrity": "sha1-bIw/uCfdQ+45GPJ7gngqt2WKb9k=",
+      "resolved": "https://registry.npmjs.org/astral-regex/-/astral-regex-1.0.0.tgz",
+      "integrity": "sha512-+Ryf6g3BKoRc7jfp7ad8tM4TtMiaWvbF/1/sQcZPkkS7ag3D5nMBCe2UfOTONtAkaG0tO0ij3C5Lwmf1EiyjHg==",
       "dev": true
     },
     "asynckit": {
       "version": "0.4.0",
-      "resolved": "https://artifactory.corp.adobe.com:443/artifactory/api/npm/npmjs-remote/asynckit/-/asynckit-0.4.0.tgz",
+      "resolved": "https://registry.npmjs.org/asynckit/-/asynckit-0.4.0.tgz",
       "integrity": "sha1-x57Zf380y48robyXkLzDZkdLS3k="
     },
     "at-least-node": {
@@ -794,7 +794,7 @@
     },
     "aws-sign2": {
       "version": "0.7.0",
-      "resolved": "https://artifactory.corp.adobe.com:443/artifactory/api/npm/npmjs-remote/aws-sign2/-/aws-sign2-0.7.0.tgz",
+      "resolved": "https://registry.npmjs.org/aws-sign2/-/aws-sign2-0.7.0.tgz",
       "integrity": "sha1-tG6JCTSpWR8tL2+G1+ap8bP+dqg="
     },
     "aws4": {
@@ -804,7 +804,7 @@
     },
     "balanced-match": {
       "version": "1.0.0",
-      "resolved": "https://artifactory.corp.adobe.com:443/artifactory/api/npm/npmjs-remote/balanced-match/-/balanced-match-1.0.0.tgz",
+      "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.0.tgz",
       "integrity": "sha1-ibTRmasr7kneFk6gK4nORi1xt2c="
     },
     "base": {
@@ -864,7 +864,7 @@
     },
     "bcrypt-pbkdf": {
       "version": "1.0.2",
-      "resolved": "https://artifactory.corp.adobe.com:443/artifactory/api/npm/npmjs-remote/bcrypt-pbkdf/-/bcrypt-pbkdf-1.0.2.tgz",
+      "resolved": "https://registry.npmjs.org/bcrypt-pbkdf/-/bcrypt-pbkdf-1.0.2.tgz",
       "integrity": "sha1-pDAdOJtqQ/m2f/PKEaP2Y342Dp4=",
       "requires": {
         "tweetnacl": "^0.14.3"
@@ -985,7 +985,7 @@
     },
     "buffer": {
       "version": "4.9.1",
-      "resolved": "https://artifactory.corp.adobe.com:443/artifactory/api/npm/npmjs-remote/buffer/-/buffer-4.9.1.tgz",
+      "resolved": "https://registry.npmjs.org/buffer/-/buffer-4.9.1.tgz",
       "integrity": "sha1-bRu2AbB6TvztlwlBMgkwJ8lbwpg=",
       "requires": {
         "base64-js": "^1.0.2",
@@ -995,7 +995,7 @@
     },
     "buffer-equal-constant-time": {
       "version": "1.0.1",
-      "resolved": "https://artifactory.corp.adobe.com:443/artifactory/api/npm/npmjs-remote/buffer-equal-constant-time/-/buffer-equal-constant-time-1.0.1.tgz",
+      "resolved": "https://registry.npmjs.org/buffer-equal-constant-time/-/buffer-equal-constant-time-1.0.1.tgz",
       "integrity": "sha1-+OcRMvf/5uAaXJaXpMbz5I1cyBk="
     },
     "bytes": {
@@ -1021,13 +1021,13 @@
     },
     "callsites": {
       "version": "3.1.0",
-      "resolved": "https://artifactory.corp.adobe.com:443/artifactory/api/npm/npmjs-remote/callsites/-/callsites-3.1.0.tgz",
-      "integrity": "sha1-s2MKvYlDQy9Us/BRkjjjPNffL3M=",
+      "resolved": "https://registry.npmjs.org/callsites/-/callsites-3.1.0.tgz",
+      "integrity": "sha512-P8BjAsXvZS+VIDUI11hHCQEv74YT67YUi5JJFNWIqL235sBmjX4+qx9Muvls5ivyNENctx46xQLQ3aTuE7ssaQ==",
       "dev": true
     },
     "cardinal": {
       "version": "2.1.1",
-      "resolved": "https://artifactory.corp.adobe.com:443/artifactory/api/npm/npmjs-remote/cardinal/-/cardinal-2.1.1.tgz",
+      "resolved": "https://registry.npmjs.org/cardinal/-/cardinal-2.1.1.tgz",
       "integrity": "sha1-fMEFXYItISlU0HsIXeolHMe8VQU=",
       "requires": {
         "ansicolors": "~0.3.2",
@@ -1036,7 +1036,7 @@
     },
     "caseless": {
       "version": "0.12.0",
-      "resolved": "https://artifactory.corp.adobe.com:443/artifactory/api/npm/npmjs-remote/caseless/-/caseless-0.12.0.tgz",
+      "resolved": "https://registry.npmjs.org/caseless/-/caseless-0.12.0.tgz",
       "integrity": "sha1-G2gcIf+EAzyCZUMJBolCDRhxUdw="
     },
     "chalk": {
@@ -1087,13 +1087,13 @@
     },
     "chardet": {
       "version": "0.7.0",
-      "resolved": "https://artifactory.corp.adobe.com:443/artifactory/api/npm/npmjs-remote/chardet/-/chardet-0.7.0.tgz",
-      "integrity": "sha1-kAlISfCTfy7twkJdDSip5fDLrZ4=",
+      "resolved": "https://registry.npmjs.org/chardet/-/chardet-0.7.0.tgz",
+      "integrity": "sha512-mT8iDcrh03qDGRRmoA2hmBJnxpllMR+0/0qlzjqZES6NdiWDcZkCNAk4rPFZ9Q85r27unkiNNg8ZOiwZXBHwcA==",
       "dev": true
     },
     "charenc": {
       "version": "0.0.2",
-      "resolved": "https://artifactory.corp.adobe.com:443/artifactory/api/npm/npmjs-remote/charenc/-/charenc-0.0.2.tgz",
+      "resolved": "https://registry.npmjs.org/charenc/-/charenc-0.0.2.tgz",
       "integrity": "sha1-wKHS86cJLgN3S/qD8UwPxXkKhmc="
     },
     "chownr": {
@@ -1130,13 +1130,13 @@
     },
     "clean-stack": {
       "version": "1.3.0",
-      "resolved": "https://artifactory.corp.adobe.com:443/artifactory/api/npm/npmjs-remote/clean-stack/-/clean-stack-1.3.0.tgz",
+      "resolved": "https://registry.npmjs.org/clean-stack/-/clean-stack-1.3.0.tgz",
       "integrity": "sha1-noIVAa6XmYbEax1m0tQy2y/UrjE="
     },
     "cli-cursor": {
       "version": "3.1.0",
-      "resolved": "https://artifactory.corp.adobe.com:443/artifactory/api/npm/npmjs-remote/cli-cursor/-/cli-cursor-3.1.0.tgz",
-      "integrity": "sha1-JkMFp65JDR0Dvwybp8kl0XU68wc=",
+      "resolved": "https://registry.npmjs.org/cli-cursor/-/cli-cursor-3.1.0.tgz",
+      "integrity": "sha512-I/zHAwsKf9FqGoXM4WWRACob9+SNukZTd94DWF57E4toouRulbCxcUh6RKUEOQlYTHJnzkPMySvPNaaSLNfLZw==",
       "dev": true,
       "requires": {
         "restore-cursor": "^3.1.0"
@@ -1253,13 +1253,13 @@
     },
     "cli-width": {
       "version": "2.2.1",
-      "resolved": "https://artifactory.corp.adobe.com:443/artifactory/api/npm/npmjs-remote/cli-width/-/cli-width-2.2.1.tgz",
-      "integrity": "sha1-sEM9C06chH7xiGik7xb9X8gnHEg=",
+      "resolved": "https://registry.npmjs.org/cli-width/-/cli-width-2.2.1.tgz",
+      "integrity": "sha512-GRMWDxpOB6Dgk2E5Uo+3eEBvtOOlimMmpbFiKuLFnQzYDavtLFY3K5ona41jgN/WdRZtG7utuVSVTL4HbZHGkw==",
       "dev": true
     },
     "collection-visit": {
       "version": "1.0.0",
-      "resolved": "https://artifactory.corp.adobe.com:443/artifactory/api/npm/npmjs-remote/collection-visit/-/collection-visit-1.0.0.tgz",
+      "resolved": "https://registry.npmjs.org/collection-visit/-/collection-visit-1.0.0.tgz",
       "integrity": "sha1-S8A3PBZLwykbTTaMgpzxqApZ3KA=",
       "requires": {
         "map-visit": "^1.0.0",
@@ -1276,7 +1276,7 @@
     },
     "color-name": {
       "version": "1.1.3",
-      "resolved": "https://artifactory.corp.adobe.com:443/artifactory/api/npm/npmjs-remote/color-name/-/color-name-1.1.3.tgz",
+      "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.3.tgz",
       "integrity": "sha1-p9BVi9icQveV3UIyj3QIMcpTvCU="
     },
     "colors": {
@@ -1299,7 +1299,7 @@
     },
     "concat-map": {
       "version": "0.0.1",
-      "resolved": "https://artifactory.corp.adobe.com:443/artifactory/api/npm/npmjs-remote/concat-map/-/concat-map-0.0.1.tgz",
+      "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
       "integrity": "sha1-2Klr13/Wjfd5OnMDajug1UBdR3s="
     },
     "content-disposition": {
@@ -1329,17 +1329,17 @@
     },
     "cookie-signature": {
       "version": "1.0.6",
-      "resolved": "https://artifactory.corp.adobe.com:443/artifactory/api/npm/npmjs-remote/cookie-signature/-/cookie-signature-1.0.6.tgz",
+      "resolved": "https://registry.npmjs.org/cookie-signature/-/cookie-signature-1.0.6.tgz",
       "integrity": "sha1-4wOogrNCzD7oylE6eZmXNNqzriw="
     },
     "copy-descriptor": {
       "version": "0.1.1",
-      "resolved": "https://artifactory.corp.adobe.com:443/artifactory/api/npm/npmjs-remote/copy-descriptor/-/copy-descriptor-0.1.1.tgz",
+      "resolved": "https://registry.npmjs.org/copy-descriptor/-/copy-descriptor-0.1.1.tgz",
       "integrity": "sha1-Z29us8OZl8LuGsOpJP1hJHSPV40="
     },
     "core-util-is": {
       "version": "1.0.2",
-      "resolved": "https://artifactory.corp.adobe.com:443/artifactory/api/npm/npmjs-remote/core-util-is/-/core-util-is-1.0.2.tgz",
+      "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz",
       "integrity": "sha1-tf1UIgqivFq1eqtxQMlAdUUDwac="
     },
     "cors": {
@@ -1365,12 +1365,12 @@
     },
     "crypt": {
       "version": "0.0.2",
-      "resolved": "https://artifactory.corp.adobe.com:443/artifactory/api/npm/npmjs-remote/crypt/-/crypt-0.0.2.tgz",
+      "resolved": "https://registry.npmjs.org/crypt/-/crypt-0.0.2.tgz",
       "integrity": "sha1-iNf/fsDfuG9xPch7u0LQRNPmxBs="
     },
     "dashdash": {
       "version": "1.14.1",
-      "resolved": "https://artifactory.corp.adobe.com:443/artifactory/api/npm/npmjs-remote/dashdash/-/dashdash-1.14.1.tgz",
+      "resolved": "https://registry.npmjs.org/dashdash/-/dashdash-1.14.1.tgz",
       "integrity": "sha1-hTz6D3y+L+1d4gMmuN1YEDX24vA=",
       "requires": {
         "assert-plus": "^1.0.0"
@@ -1386,12 +1386,12 @@
     },
     "decode-uri-component": {
       "version": "0.2.0",
-      "resolved": "https://artifactory.corp.adobe.com:443/artifactory/api/npm/npmjs-remote/decode-uri-component/-/decode-uri-component-0.2.0.tgz",
+      "resolved": "https://registry.npmjs.org/decode-uri-component/-/decode-uri-component-0.2.0.tgz",
       "integrity": "sha1-6zkTMzRYd1y4TNGh+uBiEGu4dUU="
     },
     "deep-is": {
       "version": "0.1.3",
-      "resolved": "https://artifactory.corp.adobe.com:443/artifactory/api/npm/npmjs-remote/deep-is/-/deep-is-0.1.3.tgz",
+      "resolved": "https://registry.npmjs.org/deep-is/-/deep-is-0.1.3.tgz",
       "integrity": "sha1-s2nW+128E+7PUk+RsHD+7cNXzzQ=",
       "dev": true
     },
@@ -1452,17 +1452,17 @@
     },
     "delayed-stream": {
       "version": "1.0.0",
-      "resolved": "https://artifactory.corp.adobe.com:443/artifactory/api/npm/npmjs-remote/delayed-stream/-/delayed-stream-1.0.0.tgz",
+      "resolved": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-1.0.0.tgz",
       "integrity": "sha1-3zrhmayt+31ECqrgsp4icrJOxhk="
     },
     "depd": {
       "version": "1.1.2",
-      "resolved": "https://artifactory.corp.adobe.com:443/artifactory/api/npm/npmjs-remote/depd/-/depd-1.1.2.tgz",
+      "resolved": "https://registry.npmjs.org/depd/-/depd-1.1.2.tgz",
       "integrity": "sha1-m81S4UwJd2PnSbJ0xDRu0uVgtak="
     },
     "destroy": {
       "version": "1.0.4",
-      "resolved": "https://artifactory.corp.adobe.com:443/artifactory/api/npm/npmjs-remote/destroy/-/destroy-1.0.4.tgz",
+      "resolved": "https://registry.npmjs.org/destroy/-/destroy-1.0.4.tgz",
       "integrity": "sha1-l4hXRCxEdJ5CBmE+N5RiBYJqvYA="
     },
     "detect-indent": {
@@ -1487,8 +1487,8 @@
     },
     "doctrine": {
       "version": "3.0.0",
-      "resolved": "https://artifactory.corp.adobe.com:443/artifactory/api/npm/npmjs-remote/doctrine/-/doctrine-3.0.0.tgz",
-      "integrity": "sha1-rd6+rXKmV023g2OdyHoSF3OXOWE=",
+      "resolved": "https://registry.npmjs.org/doctrine/-/doctrine-3.0.0.tgz",
+      "integrity": "sha512-yS+Q5i3hBf7GBkd4KG8a7eBNNWNGLTaEwwYWUijIYM7zrlYDM0BFXHjjPWlWZ1Rg7UaddZeIDmi9jF3HmqiQ2w==",
       "dev": true,
       "requires": {
         "esutils": "^2.0.2"
@@ -1501,7 +1501,7 @@
     },
     "ecc-jsbn": {
       "version": "0.1.2",
-      "resolved": "https://artifactory.corp.adobe.com:443/artifactory/api/npm/npmjs-remote/ecc-jsbn/-/ecc-jsbn-0.1.2.tgz",
+      "resolved": "https://registry.npmjs.org/ecc-jsbn/-/ecc-jsbn-0.1.2.tgz",
       "integrity": "sha1-OoOpBOVDUyh4dMVkt1SThoSamMk=",
       "requires": {
         "jsbn": "~0.1.0",
@@ -1518,7 +1518,7 @@
     },
     "ee-first": {
       "version": "1.1.1",
-      "resolved": "https://artifactory.corp.adobe.com:443/artifactory/api/npm/npmjs-remote/ee-first/-/ee-first-1.1.1.tgz",
+      "resolved": "https://registry.npmjs.org/ee-first/-/ee-first-1.1.1.tgz",
       "integrity": "sha1-WQxhFWsK4vTwJVcyoViyZrxWsh0="
     },
     "emoji-regex": {
@@ -1528,12 +1528,12 @@
     },
     "encodeurl": {
       "version": "1.0.2",
-      "resolved": "https://artifactory.corp.adobe.com:443/artifactory/api/npm/npmjs-remote/encodeurl/-/encodeurl-1.0.2.tgz",
+      "resolved": "https://registry.npmjs.org/encodeurl/-/encodeurl-1.0.2.tgz",
       "integrity": "sha1-rT/0yG7C0CkyL1oCw6mmBslbP1k="
     },
     "encoding": {
       "version": "0.1.12",
-      "resolved": "https://artifactory.corp.adobe.com:443/artifactory/api/npm/npmjs-remote/encoding/-/encoding-0.1.12.tgz",
+      "resolved": "https://registry.npmjs.org/encoding/-/encoding-0.1.12.tgz",
       "integrity": "sha1-U4tm8+5izRq1HsMjgp0flIDHS+s=",
       "requires": {
         "iconv-lite": "~0.4.13"
@@ -1559,18 +1559,18 @@
     },
     "escape-html": {
       "version": "1.0.3",
-      "resolved": "https://artifactory.corp.adobe.com:443/artifactory/api/npm/npmjs-remote/escape-html/-/escape-html-1.0.3.tgz",
+      "resolved": "https://registry.npmjs.org/escape-html/-/escape-html-1.0.3.tgz",
       "integrity": "sha1-Aljq5NPQwJdN4cFpGI7wBR0dGYg="
     },
     "escape-string-regexp": {
       "version": "1.0.5",
-      "resolved": "https://artifactory.corp.adobe.com:443/artifactory/api/npm/npmjs-remote/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz",
+      "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz",
       "integrity": "sha1-G2HAViGQqN/2rjuyzwIAyhMLhtQ="
     },
     "eslint": {
       "version": "6.8.0",
-      "resolved": "https://artifactory.corp.adobe.com:443/artifactory/api/npm/npmjs-remote/eslint/-/eslint-6.8.0.tgz",
-      "integrity": "sha1-YiYtZylzn5J1cjgkMC+yJ8jJP/s=",
+      "resolved": "https://registry.npmjs.org/eslint/-/eslint-6.8.0.tgz",
+      "integrity": "sha512-K+Iayyo2LtyYhDSYwz5D5QdWw0hCacNzyq1Y821Xna2xSJj7cijoLLYmLxTQgcgZ9mC61nryMy9S7GRbYpI5Ig==",
       "dev": true,
       "requires": {
         "@babel/code-frame": "^7.0.0",
@@ -1614,8 +1614,8 @@
       "dependencies": {
         "chalk": {
           "version": "2.4.2",
-          "resolved": "https://artifactory.corp.adobe.com:443/artifactory/api/npm/npmjs-remote/chalk/-/chalk-2.4.2.tgz",
-          "integrity": "sha1-zUJUFnelQzPPVBpJEIwUMrRMlCQ=",
+          "resolved": "https://registry.npmjs.org/chalk/-/chalk-2.4.2.tgz",
+          "integrity": "sha512-Mti+f9lpJNcwF4tWV8/OrTTtF1gZi+f8FqlyAdouralcFWFQWF2+NgCHShjkCb+IFBLq9buZwE1xckQU4peSuQ==",
           "dev": true,
           "requires": {
             "ansi-styles": "^3.2.1",
@@ -1625,22 +1625,22 @@
         },
         "semver": {
           "version": "6.3.0",
-          "resolved": "https://artifactory.corp.adobe.com:443/artifactory/api/npm/npmjs-remote/semver/-/semver-6.3.0.tgz",
-          "integrity": "sha1-7gpkyK9ejO6mdoexM3YeG+y9HT0=",
+          "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.0.tgz",
+          "integrity": "sha512-b39TBaTSfV6yBrapU89p5fKekE2m/NwnDocOVruQFS1/veMgdzuPcnOM34M6CwxW8jH/lxEa5rBoDeUwu5HHTw==",
           "dev": true
         }
       }
     },
     "eslint-config-problems": {
       "version": "4.0.0",
-      "resolved": "https://artifactory.corp.adobe.com:443/artifactory/api/npm/npmjs-remote/eslint-config-problems/-/eslint-config-problems-4.0.0.tgz",
-      "integrity": "sha1-PbtpygYHcM2qges78TMWLlHZxDQ=",
+      "resolved": "https://registry.npmjs.org/eslint-config-problems/-/eslint-config-problems-4.0.0.tgz",
+      "integrity": "sha512-81bplJP6QglOK9/5wxEOd7um0tgq2Kd0fLW9907dZaXq/7LpG26Q/8Uh8Qg2ppI6xe1v5LVdRpk69yHEa/anyA==",
       "dev": true
     },
     "eslint-plugin-mocha": {
       "version": "6.3.0",
-      "resolved": "https://artifactory.corp.adobe.com:443/artifactory/api/npm/npmjs-remote/eslint-plugin-mocha/-/eslint-plugin-mocha-6.3.0.tgz",
-      "integrity": "sha1-cr/QalxDI+F+MO9BzXJgMOjNuP0=",
+      "resolved": "https://registry.npmjs.org/eslint-plugin-mocha/-/eslint-plugin-mocha-6.3.0.tgz",
+      "integrity": "sha512-Cd2roo8caAyG21oKaaNTj7cqeYRWW1I2B5SfpKRp0Ip1gkfwoR1Ow0IGlPWnNjzywdF4n+kHL8/9vM6zCJUxdg==",
       "dev": true,
       "requires": {
         "eslint-utils": "^2.0.0",
@@ -1649,8 +1649,8 @@
       "dependencies": {
         "eslint-utils": {
           "version": "2.0.0",
-          "resolved": "https://artifactory.corp.adobe.com:443/artifactory/api/npm/npmjs-remote/eslint-utils/-/eslint-utils-2.0.0.tgz",
-          "integrity": "sha1-e+HMcPJ6cqds0UqmmLyr7WiQ4c0=",
+          "resolved": "https://registry.npmjs.org/eslint-utils/-/eslint-utils-2.0.0.tgz",
+          "integrity": "sha512-0HCPuJv+7Wv1bACm8y5/ECVfYdfsAm9xmVb7saeFlxjPYALefjhbYoCkBjPdPzGH8wWyTpAez82Fh3VKYEZ8OA==",
           "dev": true,
           "requires": {
             "eslint-visitor-keys": "^1.1.0"
@@ -1660,8 +1660,8 @@
     },
     "eslint-plugin-notice": {
       "version": "0.9.10",
-      "resolved": "https://artifactory.corp.adobe.com:443/artifactory/api/npm/npmjs-remote/eslint-plugin-notice/-/eslint-plugin-notice-0.9.10.tgz",
-      "integrity": "sha1-ic9jd78cAEohnE5UEyHqkSW0CMg=",
+      "resolved": "https://registry.npmjs.org/eslint-plugin-notice/-/eslint-plugin-notice-0.9.10.tgz",
+      "integrity": "sha512-rF79EuqdJKu9hhTmwUkNeSvLmmq03m/NXq/NHwUENHbdJ0wtoyOjxZBhW4QCug8v5xYE6cGe3AWkGqSIe9KUbQ==",
       "dev": true,
       "requires": {
         "find-root": "^1.1.0",
@@ -1671,8 +1671,8 @@
     },
     "eslint-scope": {
       "version": "5.0.0",
-      "resolved": "https://artifactory.corp.adobe.com:443/artifactory/api/npm/npmjs-remote/eslint-scope/-/eslint-scope-5.0.0.tgz",
-      "integrity": "sha1-6HyIh8c+jR7ITxylkWRcNYv8j7k=",
+      "resolved": "https://registry.npmjs.org/eslint-scope/-/eslint-scope-5.0.0.tgz",
+      "integrity": "sha512-oYrhJW7S0bxAFDvWqzvMPRm6pcgcnWc4QnofCAqRTRfQC0JcwenzGglTtsLyIuuWFfkqDG9vz67cnttSd53djw==",
       "dev": true,
       "requires": {
         "esrecurse": "^4.1.0",
@@ -1681,8 +1681,8 @@
     },
     "eslint-utils": {
       "version": "1.4.3",
-      "resolved": "https://artifactory.corp.adobe.com:443/artifactory/api/npm/npmjs-remote/eslint-utils/-/eslint-utils-1.4.3.tgz",
-      "integrity": "sha1-dP7HxU0Hdrb2fgJRBAtYBlZOmB8=",
+      "resolved": "https://registry.npmjs.org/eslint-utils/-/eslint-utils-1.4.3.tgz",
+      "integrity": "sha512-fbBN5W2xdY45KulGXmLHZ3c3FHfVYmKg0IrAKGOkT/464PQsx2UeIzfz1RmEci+KLm1bBaAzZAh8+/E+XAeZ8Q==",
       "dev": true,
       "requires": {
         "eslint-visitor-keys": "^1.1.0"
@@ -1690,14 +1690,14 @@
     },
     "eslint-visitor-keys": {
       "version": "1.1.0",
-      "resolved": "https://artifactory.corp.adobe.com:443/artifactory/api/npm/npmjs-remote/eslint-visitor-keys/-/eslint-visitor-keys-1.1.0.tgz",
-      "integrity": "sha1-4qgs6oT/JGrW+1f5veW0ZiFFnsI=",
+      "resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-1.1.0.tgz",
+      "integrity": "sha512-8y9YjtM1JBJU/A9Kc+SbaOV4y29sSWckBwMHa+FGtVj5gN/sbnKDf6xJUl+8g7FAij9LVaP8C24DUiH/f/2Z9A==",
       "dev": true
     },
     "espree": {
       "version": "6.2.1",
-      "resolved": "https://artifactory.corp.adobe.com:443/artifactory/api/npm/npmjs-remote/espree/-/espree-6.2.1.tgz",
-      "integrity": "sha1-d/xy4f10SiBSwg84pbV1gy6Cc0o=",
+      "resolved": "https://registry.npmjs.org/espree/-/espree-6.2.1.tgz",
+      "integrity": "sha512-ysCxRQY3WaXJz9tdbWOwuWr5Y/XrPTGX9Kiz3yoUXwW0VZ4w30HTkQLaGx/+ttFjF8i+ACbArnB4ce68a9m5hw==",
       "dev": true,
       "requires": {
         "acorn": "^7.1.1",
@@ -1712,8 +1712,8 @@
     },
     "esquery": {
       "version": "1.3.1",
-      "resolved": "https://artifactory.corp.adobe.com:443/artifactory/api/npm/npmjs-remote/esquery/-/esquery-1.3.1.tgz",
-      "integrity": "sha1-t4tYKKqOIU4p+3TE1bdS4cAz2lc=",
+      "resolved": "https://registry.npmjs.org/esquery/-/esquery-1.3.1.tgz",
+      "integrity": "sha512-olpvt9QG0vniUBZspVRN6lwB7hOZoTRtT+jzR+tS4ffYx2mzbw+z0XCOk44aaLYKApNX5nMm+E+P6o25ip/DHQ==",
       "dev": true,
       "requires": {
         "estraverse": "^5.1.0"
@@ -1721,16 +1721,16 @@
       "dependencies": {
         "estraverse": {
           "version": "5.1.0",
-          "resolved": "https://artifactory.corp.adobe.com:443/artifactory/api/npm/npmjs-remote/estraverse/-/estraverse-5.1.0.tgz",
-          "integrity": "sha1-N0MJ05/ZNa5QDnuS6Ka0xyDllkI=",
+          "resolved": "https://registry.npmjs.org/estraverse/-/estraverse-5.1.0.tgz",
+          "integrity": "sha512-FyohXK+R0vE+y1nHLoBM7ZTyqRpqAlhdZHCWIWEviFLiGB8b04H6bQs8G+XTthacvT8VuwvteiP7RJSxMs8UEw==",
           "dev": true
         }
       }
     },
     "esrecurse": {
       "version": "4.2.1",
-      "resolved": "https://artifactory.corp.adobe.com:443/artifactory/api/npm/npmjs-remote/esrecurse/-/esrecurse-4.2.1.tgz",
-      "integrity": "sha1-AHo7n9vCs7uH5IeeoZyS/b05Qs8=",
+      "resolved": "https://registry.npmjs.org/esrecurse/-/esrecurse-4.2.1.tgz",
+      "integrity": "sha512-64RBB++fIOAXPw3P9cy89qfMlvZEXZkqqJkjqqXIvzP5ezRZjW+lPWjw35UX/3EhUPFYbg5ER4JYgDw4007/DQ==",
       "dev": true,
       "requires": {
         "estraverse": "^4.1.0"
@@ -1738,19 +1738,19 @@
     },
     "estraverse": {
       "version": "4.3.0",
-      "resolved": "https://artifactory.corp.adobe.com:443/artifactory/api/npm/npmjs-remote/estraverse/-/estraverse-4.3.0.tgz",
-      "integrity": "sha1-OYrT88WiSUi+dyXoPRGn3ijNvR0=",
+      "resolved": "https://registry.npmjs.org/estraverse/-/estraverse-4.3.0.tgz",
+      "integrity": "sha512-39nnKffWz8xN1BU/2c79n9nB9HDzo0niYUqx6xyqUnyoAnQyyWpOTdZEeiCch8BBu515t4wp9ZmgVfVhn9EBpw==",
       "dev": true
     },
     "esutils": {
       "version": "2.0.3",
-      "resolved": "https://artifactory.corp.adobe.com:443/artifactory/api/npm/npmjs-remote/esutils/-/esutils-2.0.3.tgz",
-      "integrity": "sha1-dNLrTeC42hKTcRkQ1Qd1ubcQ72Q=",
+      "resolved": "https://registry.npmjs.org/esutils/-/esutils-2.0.3.tgz",
+      "integrity": "sha512-kVscqXk4OCp68SZ0dkgEKVi6/8ij300KBWTJq32P/dYeWTSwK41WyTxalN1eRmA5Z9UU/LX9D7FWSmV9SAYx6g==",
       "dev": true
     },
     "etag": {
       "version": "1.8.1",
-      "resolved": "https://artifactory.corp.adobe.com:443/artifactory/api/npm/npmjs-remote/etag/-/etag-1.8.1.tgz",
+      "resolved": "https://registry.npmjs.org/etag/-/etag-1.8.1.tgz",
       "integrity": "sha1-Qa4u62XvpiJorr/qg6x9eSmbCIc="
     },
     "event-target-shim": {
@@ -1788,7 +1788,7 @@
     },
     "expand-brackets": {
       "version": "2.1.4",
-      "resolved": "https://artifactory.corp.adobe.com:443/artifactory/api/npm/npmjs-remote/expand-brackets/-/expand-brackets-2.1.4.tgz",
+      "resolved": "https://registry.npmjs.org/expand-brackets/-/expand-brackets-2.1.4.tgz",
       "integrity": "sha1-t3c14xXOMPa27/D4OwQVGiJEliI=",
       "requires": {
         "debug": "^2.3.3",
@@ -1810,7 +1810,7 @@
         },
         "define-property": {
           "version": "0.2.5",
-          "resolved": "https://artifactory.corp.adobe.com:443/artifactory/api/npm/npmjs-remote/define-property/-/define-property-0.2.5.tgz",
+          "resolved": "https://registry.npmjs.org/define-property/-/define-property-0.2.5.tgz",
           "integrity": "sha1-w1se+RjsPJkPmlvFe+BKrOxcgRY=",
           "requires": {
             "is-descriptor": "^0.1.0"
@@ -1818,7 +1818,7 @@
         },
         "extend-shallow": {
           "version": "2.0.1",
-          "resolved": "https://artifactory.corp.adobe.com:443/artifactory/api/npm/npmjs-remote/extend-shallow/-/extend-shallow-2.0.1.tgz",
+          "resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-2.0.1.tgz",
           "integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
           "requires": {
             "is-extendable": "^0.1.0"
@@ -1826,7 +1826,7 @@
         },
         "ms": {
           "version": "2.0.0",
-          "resolved": "https://artifactory.corp.adobe.com:443/artifactory/api/npm/npmjs-remote/ms/-/ms-2.0.0.tgz",
+          "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
           "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g="
         }
       }
@@ -1903,7 +1903,7 @@
     },
     "extend-shallow": {
       "version": "3.0.2",
-      "resolved": "https://artifactory.corp.adobe.com:443/artifactory/api/npm/npmjs-remote/extend-shallow/-/extend-shallow-3.0.2.tgz",
+      "resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-3.0.2.tgz",
       "integrity": "sha1-Jqcarwc7OfshJxcnRhMcJwQCjbg=",
       "requires": {
         "assign-symbols": "^1.0.0",
@@ -1922,8 +1922,8 @@
     },
     "external-editor": {
       "version": "3.1.0",
-      "resolved": "https://artifactory.corp.adobe.com:443/artifactory/api/npm/npmjs-remote/external-editor/-/external-editor-3.1.0.tgz",
-      "integrity": "sha1-ywP3QL764D6k0oPK7SdBqD8zVJU=",
+      "resolved": "https://registry.npmjs.org/external-editor/-/external-editor-3.1.0.tgz",
+      "integrity": "sha512-hMQ4CX1p1izmuLYyZqLMO/qGNw10wSv9QDCPfzXfyFrOaCSSoRfqE1Kf1s5an66J5JZC62NewG+mK49jOCtQew==",
       "dev": true,
       "requires": {
         "chardet": "^0.7.0",
@@ -1992,12 +1992,12 @@
     },
     "extract-stack": {
       "version": "1.0.0",
-      "resolved": "https://artifactory.corp.adobe.com:443/artifactory/api/npm/npmjs-remote/extract-stack/-/extract-stack-1.0.0.tgz",
+      "resolved": "https://registry.npmjs.org/extract-stack/-/extract-stack-1.0.0.tgz",
       "integrity": "sha1-uXrK+UQe6iMyUpYktzL8WhyBZfo="
     },
     "extsprintf": {
       "version": "1.3.0",
-      "resolved": "https://artifactory.corp.adobe.com:443/artifactory/api/npm/npmjs-remote/extsprintf/-/extsprintf-1.3.0.tgz",
+      "resolved": "https://registry.npmjs.org/extsprintf/-/extsprintf-1.3.0.tgz",
       "integrity": "sha1-lpGEQOMEGnpBT4xS48V06zw+HgU="
     },
     "fancy-test": {
@@ -2104,7 +2104,7 @@
     },
     "fast-levenshtein": {
       "version": "2.0.6",
-      "resolved": "https://artifactory.corp.adobe.com:443/artifactory/api/npm/npmjs-remote/fast-levenshtein/-/fast-levenshtein-2.0.6.tgz",
+      "resolved": "https://registry.npmjs.org/fast-levenshtein/-/fast-levenshtein-2.0.6.tgz",
       "integrity": "sha1-PYpcZog6FqMMqGQ+hR8Zuqd5eRc=",
       "dev": true
     },
@@ -2119,8 +2119,8 @@
     },
     "figures": {
       "version": "3.2.0",
-      "resolved": "https://artifactory.corp.adobe.com:443/artifactory/api/npm/npmjs-remote/figures/-/figures-3.2.0.tgz",
-      "integrity": "sha1-YlwYvSk8YE3EqN2y/r8MiDQXRq8=",
+      "resolved": "https://registry.npmjs.org/figures/-/figures-3.2.0.tgz",
+      "integrity": "sha512-yaduQFRKLXYOGgEn6AZau90j3ggSOyiqXU0F9JZfeXYhNa+Jk4X+s45A2zg5jns87GAFa34BBm2kXw4XpNcbdg==",
       "dev": true,
       "requires": {
         "escape-string-regexp": "^1.0.5"
@@ -2128,8 +2128,8 @@
     },
     "file-entry-cache": {
       "version": "5.0.1",
-      "resolved": "https://artifactory.corp.adobe.com:443/artifactory/api/npm/npmjs-remote/file-entry-cache/-/file-entry-cache-5.0.1.tgz",
-      "integrity": "sha1-yg9u+m3T1WEzP7FFFQZcL6/fQ5w=",
+      "resolved": "https://registry.npmjs.org/file-entry-cache/-/file-entry-cache-5.0.1.tgz",
+      "integrity": "sha512-bCg29ictuBaKUwwArK4ouCaqDgLZcysCFLmM/Yn/FDoqndh/9vNuQfXRDvTuXKLxfD/JtZQGKFT8MGcJBK644g==",
       "dev": true,
       "requires": {
         "flat-cache": "^2.0.1"
@@ -2137,7 +2137,7 @@
     },
     "fill-range": {
       "version": "4.0.0",
-      "resolved": "https://artifactory.corp.adobe.com:443/artifactory/api/npm/npmjs-remote/fill-range/-/fill-range-4.0.0.tgz",
+      "resolved": "https://registry.npmjs.org/fill-range/-/fill-range-4.0.0.tgz",
       "integrity": "sha1-1USBHUKPmOsGpj3EAtJAPDKMOPc=",
       "requires": {
         "extend-shallow": "^2.0.1",
@@ -2148,7 +2148,7 @@
       "dependencies": {
         "extend-shallow": {
           "version": "2.0.1",
-          "resolved": "https://artifactory.corp.adobe.com:443/artifactory/api/npm/npmjs-remote/extend-shallow/-/extend-shallow-2.0.1.tgz",
+          "resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-2.0.1.tgz",
           "integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
           "requires": {
             "is-extendable": "^0.1.0"
@@ -2187,8 +2187,8 @@
     },
     "find-root": {
       "version": "1.1.0",
-      "resolved": "https://artifactory.corp.adobe.com:443/artifactory/api/npm/npmjs-remote/find-root/-/find-root-1.1.0.tgz",
-      "integrity": "sha1-q8/Iunb3CMQql7PWhbfpRQv7nOQ=",
+      "resolved": "https://registry.npmjs.org/find-root/-/find-root-1.1.0.tgz",
+      "integrity": "sha512-NKfW6bec6GfKc0SGx1e07QZY9PE99u0Bft/0rzSD5k3sO/vwkVUpDUKVm5Gpp5Ue3YfShPFTX2070tDs5kB9Ng==",
       "dev": true
     },
     "find-up": {
@@ -2224,8 +2224,8 @@
     },
     "flat-cache": {
       "version": "2.0.1",
-      "resolved": "https://artifactory.corp.adobe.com:443/artifactory/api/npm/npmjs-remote/flat-cache/-/flat-cache-2.0.1.tgz",
-      "integrity": "sha1-XSltbwS9pEpGMKMBQTvbwuwIXsA=",
+      "resolved": "https://registry.npmjs.org/flat-cache/-/flat-cache-2.0.1.tgz",
+      "integrity": "sha512-LoQe6yDuUMDzQAEH8sgmh4Md6oZnc/7PjtwjNFSzveXqSHt6ka9fPBuso7IGf9Rz4uqnSnWiFH2B/zj24a5ReA==",
       "dev": true,
       "requires": {
         "flatted": "^2.0.0",
@@ -2235,8 +2235,8 @@
       "dependencies": {
         "rimraf": {
           "version": "2.6.3",
-          "resolved": "https://artifactory.corp.adobe.com:443/artifactory/api/npm/npmjs-remote/rimraf/-/rimraf-2.6.3.tgz",
-          "integrity": "sha1-stEE/g2Psnz54KHNqCYt04M8bKs=",
+          "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.6.3.tgz",
+          "integrity": "sha512-mwqeW5XsA2qAejG46gYdENaxXjx9onRNCfn7L0duuP4hCuTIi/QO7PDK07KJfp1d+izWPrzEJDcSqBa0OZQriA==",
           "dev": true,
           "requires": {
             "glob": "^7.1.3"
@@ -2246,18 +2246,18 @@
     },
     "flatted": {
       "version": "2.0.2",
-      "resolved": "https://artifactory.corp.adobe.com:443/artifactory/api/npm/npmjs-remote/flatted/-/flatted-2.0.2.tgz",
-      "integrity": "sha1-RXWyHivO50NKqb5mL0t7X5wrUTg=",
+      "resolved": "https://registry.npmjs.org/flatted/-/flatted-2.0.2.tgz",
+      "integrity": "sha512-r5wGx7YeOwNWNlCA0wQ86zKyDLMQr+/RB8xy74M4hTphfmjlijTSSXGuH8rnvKZnfT9i+75zmd8jcKdMR4O6jA==",
       "dev": true
     },
     "for-in": {
       "version": "1.0.2",
-      "resolved": "https://artifactory.corp.adobe.com:443/artifactory/api/npm/npmjs-remote/for-in/-/for-in-1.0.2.tgz",
+      "resolved": "https://registry.npmjs.org/for-in/-/for-in-1.0.2.tgz",
       "integrity": "sha1-gQaNKVqBQuwKxybG4iAMMPttXoA="
     },
     "forever-agent": {
       "version": "0.6.1",
-      "resolved": "https://artifactory.corp.adobe.com:443/artifactory/api/npm/npmjs-remote/forever-agent/-/forever-agent-0.6.1.tgz",
+      "resolved": "https://registry.npmjs.org/forever-agent/-/forever-agent-0.6.1.tgz",
       "integrity": "sha1-+8cfDEGt6zf5bFd60e1C2P2sypE="
     },
     "form-data": {
@@ -2277,12 +2277,12 @@
     },
     "forwarded": {
       "version": "0.1.2",
-      "resolved": "https://artifactory.corp.adobe.com:443/artifactory/api/npm/npmjs-remote/forwarded/-/forwarded-0.1.2.tgz",
+      "resolved": "https://registry.npmjs.org/forwarded/-/forwarded-0.1.2.tgz",
       "integrity": "sha1-mMI9qxF1ZXuMBXPozszZGw/xjIQ="
     },
     "fragment-cache": {
       "version": "0.2.1",
-      "resolved": "https://artifactory.corp.adobe.com:443/artifactory/api/npm/npmjs-remote/fragment-cache/-/fragment-cache-0.2.1.tgz",
+      "resolved": "https://registry.npmjs.org/fragment-cache/-/fragment-cache-0.2.1.tgz",
       "integrity": "sha1-QpD60n8T6Jvn8zeZxrxaCr//DRk=",
       "requires": {
         "map-cache": "^0.2.2"
@@ -2290,7 +2290,7 @@
     },
     "fresh": {
       "version": "0.5.2",
-      "resolved": "https://artifactory.corp.adobe.com:443/artifactory/api/npm/npmjs-remote/fresh/-/fresh-0.5.2.tgz",
+      "resolved": "https://registry.npmjs.org/fresh/-/fresh-0.5.2.tgz",
       "integrity": "sha1-PYyt2Q2XZWn6g1qx+OSyOhBWBac="
     },
     "fs-constants": {
@@ -2311,12 +2311,12 @@
     },
     "fs.realpath": {
       "version": "1.0.0",
-      "resolved": "https://artifactory.corp.adobe.com:443/artifactory/api/npm/npmjs-remote/fs.realpath/-/fs.realpath-1.0.0.tgz",
+      "resolved": "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz",
       "integrity": "sha1-FQStJSMVjKpA20onh8sBQRmU6k8="
     },
     "functional-red-black-tree": {
       "version": "1.0.1",
-      "resolved": "https://artifactory.corp.adobe.com:443/artifactory/api/npm/npmjs-remote/functional-red-black-tree/-/functional-red-black-tree-1.0.1.tgz",
+      "resolved": "https://registry.npmjs.org/functional-red-black-tree/-/functional-red-black-tree-1.0.1.tgz",
       "integrity": "sha1-GwqzvVU7Kg1jmdKcDj6gslIHgyc=",
       "dev": true
     },
@@ -2336,12 +2336,12 @@
     },
     "get-value": {
       "version": "2.0.6",
-      "resolved": "https://artifactory.corp.adobe.com:443/artifactory/api/npm/npmjs-remote/get-value/-/get-value-2.0.6.tgz",
+      "resolved": "https://registry.npmjs.org/get-value/-/get-value-2.0.6.tgz",
       "integrity": "sha1-3BXKHGcjh8p2vTesCjlbogQqLCg="
     },
     "getpass": {
       "version": "0.1.7",
-      "resolved": "https://artifactory.corp.adobe.com:443/artifactory/api/npm/npmjs-remote/getpass/-/getpass-0.1.7.tgz",
+      "resolved": "https://registry.npmjs.org/getpass/-/getpass-0.1.7.tgz",
       "integrity": "sha1-Xv+OPmhNVprkyysSgmBOi6YhSfo=",
       "requires": {
         "assert-plus": "^1.0.0"
@@ -2388,8 +2388,8 @@
     },
     "globals": {
       "version": "12.4.0",
-      "resolved": "https://artifactory.corp.adobe.com:443/artifactory/api/npm/npmjs-remote/globals/-/globals-12.4.0.tgz",
-      "integrity": "sha1-oYgTV2pBsAokqX5/gVkYwuGZJfg=",
+      "resolved": "https://registry.npmjs.org/globals/-/globals-12.4.0.tgz",
+      "integrity": "sha512-BWICuzzDvDoH54NHKCseDanAhE3CeDorgDL5MT6LMXXj2WCnd9UC2szdk4AWLfjdgNBCXLUanXYcpBBKOSWGwg==",
       "dev": true,
       "requires": {
         "type-fest": "^0.8.1"
@@ -2438,7 +2438,7 @@
     },
     "har-schema": {
       "version": "2.0.0",
-      "resolved": "https://artifactory.corp.adobe.com:443/artifactory/api/npm/npmjs-remote/har-schema/-/har-schema-2.0.0.tgz",
+      "resolved": "https://registry.npmjs.org/har-schema/-/har-schema-2.0.0.tgz",
       "integrity": "sha1-qUwiJOvKwEeCoNkDVSHyRzW37JI="
     },
     "har-validator": {
@@ -2452,12 +2452,12 @@
     },
     "has-flag": {
       "version": "3.0.0",
-      "resolved": "https://artifactory.corp.adobe.com:443/artifactory/api/npm/npmjs-remote/has-flag/-/has-flag-3.0.0.tgz",
+      "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-3.0.0.tgz",
       "integrity": "sha1-tdRU3CGZriJWmfNGfloH87lVuv0="
     },
     "has-value": {
       "version": "1.0.0",
-      "resolved": "https://artifactory.corp.adobe.com:443/artifactory/api/npm/npmjs-remote/has-value/-/has-value-1.0.0.tgz",
+      "resolved": "https://registry.npmjs.org/has-value/-/has-value-1.0.0.tgz",
       "integrity": "sha1-GLKB2lhbHFxR3vJMkw7SmgvmsXc=",
       "requires": {
         "get-value": "^2.0.6",
@@ -2467,7 +2467,7 @@
     },
     "has-values": {
       "version": "1.0.0",
-      "resolved": "https://artifactory.corp.adobe.com:443/artifactory/api/npm/npmjs-remote/has-values/-/has-values-1.0.0.tgz",
+      "resolved": "https://registry.npmjs.org/has-values/-/has-values-1.0.0.tgz",
       "integrity": "sha1-lbC2P+whRmGab+V/51Yo1aOe/k8=",
       "requires": {
         "is-number": "^3.0.0",
@@ -2476,7 +2476,7 @@
       "dependencies": {
         "kind-of": {
           "version": "4.0.0",
-          "resolved": "https://artifactory.corp.adobe.com:443/artifactory/api/npm/npmjs-remote/kind-of/-/kind-of-4.0.0.tgz",
+          "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-4.0.0.tgz",
           "integrity": "sha1-IIE989cSkosgc3hpGkUGb65y3Vc=",
           "requires": {
             "is-buffer": "^1.1.5"
@@ -2536,7 +2536,7 @@
     },
     "http-signature": {
       "version": "1.2.0",
-      "resolved": "https://artifactory.corp.adobe.com:443/artifactory/api/npm/npmjs-remote/http-signature/-/http-signature-1.2.0.tgz",
+      "resolved": "https://registry.npmjs.org/http-signature/-/http-signature-1.2.0.tgz",
       "integrity": "sha1-muzZJRFHcvPZW2WmCruPfBj7rOE=",
       "requires": {
         "assert-plus": "^1.0.0",
@@ -2573,14 +2573,14 @@
     },
     "ignore": {
       "version": "4.0.6",
-      "resolved": "https://artifactory.corp.adobe.com:443/artifactory/api/npm/npmjs-remote/ignore/-/ignore-4.0.6.tgz",
-      "integrity": "sha1-dQ49tYYgh7RzfrrIIH/9HvJ7Jfw=",
+      "resolved": "https://registry.npmjs.org/ignore/-/ignore-4.0.6.tgz",
+      "integrity": "sha512-cyFDKrqc/YdcWFniJhzI42+AzS+gNwmUzOSFcRCQYwySuBBBy/KjuxWLZ/FHEH6Moq1NizMOBWyTcv8O4OZIMg==",
       "dev": true
     },
     "import-fresh": {
       "version": "3.2.1",
-      "resolved": "https://artifactory.corp.adobe.com:443/artifactory/api/npm/npmjs-remote/import-fresh/-/import-fresh-3.2.1.tgz",
-      "integrity": "sha1-Yz/2GFBueTr1rJG/SLcmd+FcvmY=",
+      "resolved": "https://registry.npmjs.org/import-fresh/-/import-fresh-3.2.1.tgz",
+      "integrity": "sha512-6e1q1cnWP2RXD9/keSkxHScg508CdXqXWgWBaETNhyuBFz+kUZlKboh+ISK+bU++DmbHimVBrOz/zzPe0sZ3sQ==",
       "dev": true,
       "requires": {
         "parent-module": "^1.0.0",
@@ -2589,18 +2589,18 @@
     },
     "imurmurhash": {
       "version": "0.1.4",
-      "resolved": "https://artifactory.corp.adobe.com:443/artifactory/api/npm/npmjs-remote/imurmurhash/-/imurmurhash-0.1.4.tgz",
+      "resolved": "https://registry.npmjs.org/imurmurhash/-/imurmurhash-0.1.4.tgz",
       "integrity": "sha1-khi5srkoojixPcT7a21XbyMUU+o=",
       "dev": true
     },
     "indent-string": {
       "version": "3.2.0",
-      "resolved": "https://artifactory.corp.adobe.com:443/artifactory/api/npm/npmjs-remote/indent-string/-/indent-string-3.2.0.tgz",
+      "resolved": "https://registry.npmjs.org/indent-string/-/indent-string-3.2.0.tgz",
       "integrity": "sha1-Sl/W0nzDMvN+VBmlBNu4NxBckok="
     },
     "inflight": {
       "version": "1.0.6",
-      "resolved": "https://artifactory.corp.adobe.com:443/artifactory/api/npm/npmjs-remote/inflight/-/inflight-1.0.6.tgz",
+      "resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.6.tgz",
       "integrity": "sha1-Sb1jMdfQLQwJvJEKEHW6gWW1bfk=",
       "requires": {
         "once": "^1.3.0",
@@ -2614,8 +2614,8 @@
     },
     "inquirer": {
       "version": "7.1.0",
-      "resolved": "https://artifactory.corp.adobe.com:443/artifactory/api/npm/npmjs-remote/inquirer/-/inquirer-7.1.0.tgz",
-      "integrity": "sha1-EpigGFmIPhfHJkuChwrhA0+S3Sk=",
+      "resolved": "https://registry.npmjs.org/inquirer/-/inquirer-7.1.0.tgz",
+      "integrity": "sha512-5fJMWEmikSYu0nv/flMc475MhGbB7TSPd/2IpFV4I4rMklboCH2rQjYY5kKiYGHqUF9gvaambupcJFFG9dvReg==",
       "dev": true,
       "requires": {
         "ansi-escapes": "^4.2.1",
@@ -2635,8 +2635,8 @@
       "dependencies": {
         "ansi-escapes": {
           "version": "4.3.1",
-          "resolved": "https://artifactory.corp.adobe.com:443/artifactory/api/npm/npmjs-remote/ansi-escapes/-/ansi-escapes-4.3.1.tgz",
-          "integrity": "sha1-pcR8xDGB8fOP/XB2g3cA05VSKmE=",
+          "resolved": "https://registry.npmjs.org/ansi-escapes/-/ansi-escapes-4.3.1.tgz",
+          "integrity": "sha512-JWF7ocqNrp8u9oqpgV+wH5ftbt+cfvv+PTjOvKLT3AdYly/LmORARfEVT1iyjwN+4MqE5UmVKoAdIBqeoCHgLA==",
           "dev": true,
           "requires": {
             "type-fest": "^0.11.0"
@@ -2644,14 +2644,14 @@
         },
         "ansi-regex": {
           "version": "5.0.0",
-          "resolved": "https://artifactory.corp.adobe.com:443/artifactory/api/npm/npmjs-remote/ansi-regex/-/ansi-regex-5.0.0.tgz",
-          "integrity": "sha1-OIU59VF5vzkznIGvMKZU1p+Hy3U=",
+          "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.0.tgz",
+          "integrity": "sha512-bY6fj56OUQ0hU1KjFNDQuJFezqKdrAyFdIevADiqrWHwSlbmBNMHp5ak2f40Pm8JTFyM2mqxkG6ngkHO11f/lg==",
           "dev": true
         },
         "ansi-styles": {
           "version": "4.2.1",
-          "resolved": "https://artifactory.corp.adobe.com:443/artifactory/api/npm/npmjs-remote/ansi-styles/-/ansi-styles-4.2.1.tgz",
-          "integrity": "sha1-kK51xCTQCNJiTFvynq0xd+v881k=",
+          "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.2.1.tgz",
+          "integrity": "sha512-9VGjrMsG1vePxcSweQsN20KY/c4zN0h9fLjqAbwbPfahM3t+NL+M9HC8xeXG2I8pX5NoamTGNuomEUFI7fcUjA==",
           "dev": true,
           "requires": {
             "@types/color-name": "^1.1.1",
@@ -2660,8 +2660,8 @@
         },
         "chalk": {
           "version": "3.0.0",
-          "resolved": "https://artifactory.corp.adobe.com:443/artifactory/api/npm/npmjs-remote/chalk/-/chalk-3.0.0.tgz",
-          "integrity": "sha1-P3PCv1JlkfV0zEksUeJFY0n4ROQ=",
+          "resolved": "https://registry.npmjs.org/chalk/-/chalk-3.0.0.tgz",
+          "integrity": "sha512-4D3B6Wf41KOYRFdszmDqMCGq5VV/uMAB273JILmO+3jAlh8X4qDtdtgCR3fxtbLEMzSx22QdhnDcJvu2u1fVwg==",
           "dev": true,
           "requires": {
             "ansi-styles": "^4.1.0",
@@ -2670,8 +2670,8 @@
         },
         "color-convert": {
           "version": "2.0.1",
-          "resolved": "https://artifactory.corp.adobe.com:443/artifactory/api/npm/npmjs-remote/color-convert/-/color-convert-2.0.1.tgz",
-          "integrity": "sha1-ctOmjVmMm9s68q0ehPIdiWq9TeM=",
+          "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
+          "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
           "dev": true,
           "requires": {
             "color-name": "~1.1.4"
@@ -2679,32 +2679,32 @@
         },
         "color-name": {
           "version": "1.1.4",
-          "resolved": "https://artifactory.corp.adobe.com:443/artifactory/api/npm/npmjs-remote/color-name/-/color-name-1.1.4.tgz",
-          "integrity": "sha1-wqCah6y95pVD3m9j+jmVyCbFNqI=",
+          "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
+          "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
           "dev": true
         },
         "emoji-regex": {
           "version": "8.0.0",
-          "resolved": "https://artifactory.corp.adobe.com:443/artifactory/api/npm/npmjs-remote/emoji-regex/-/emoji-regex-8.0.0.tgz",
-          "integrity": "sha1-6Bj9ac5cz8tARZT4QpY79TFkzDc=",
+          "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-8.0.0.tgz",
+          "integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==",
           "dev": true
         },
         "has-flag": {
           "version": "4.0.0",
-          "resolved": "https://artifactory.corp.adobe.com:443/artifactory/api/npm/npmjs-remote/has-flag/-/has-flag-4.0.0.tgz",
-          "integrity": "sha1-lEdx/ZyByBJlxNaUGGDaBrtZR5s=",
+          "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
+          "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
           "dev": true
         },
         "is-fullwidth-code-point": {
           "version": "3.0.0",
-          "resolved": "https://artifactory.corp.adobe.com:443/artifactory/api/npm/npmjs-remote/is-fullwidth-code-point/-/is-fullwidth-code-point-3.0.0.tgz",
-          "integrity": "sha1-8Rb4Bk/pCz94RKOJl8C3UFEmnx0=",
+          "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-3.0.0.tgz",
+          "integrity": "sha512-zymm5+u+sCsSWyD9qNaejV3DFvhCKclKdizYaJUuHA83RLjb7nSuGnddCHGv0hk+KY7BMAlsWeK4Ueg6EV6XQg==",
           "dev": true
         },
         "string-width": {
           "version": "4.2.0",
-          "resolved": "https://artifactory.corp.adobe.com:443/artifactory/api/npm/npmjs-remote/string-width/-/string-width-4.2.0.tgz",
-          "integrity": "sha1-lSGCxGzHssMT0VluYjmSvRY7crU=",
+          "resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.0.tgz",
+          "integrity": "sha512-zUz5JD+tgqtuDjMhwIg5uFVV3dtqZ9yQJlZVfq4I01/K5Paj5UHj7VyrQOJvzawSVlKpObApbfD0Ed6yJc+1eg==",
           "dev": true,
           "requires": {
             "emoji-regex": "^8.0.0",
@@ -2714,8 +2714,8 @@
         },
         "strip-ansi": {
           "version": "6.0.0",
-          "resolved": "https://artifactory.corp.adobe.com:443/artifactory/api/npm/npmjs-remote/strip-ansi/-/strip-ansi-6.0.0.tgz",
-          "integrity": "sha1-CxVx3XZpzNTz4G4U7x7tJiJa5TI=",
+          "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.0.tgz",
+          "integrity": "sha512-AuvKTrTfQNYNIctbR1K/YGTR1756GycPsg7b9bdV9Duqur4gv6aKqHXah67Z8ImS7WEz5QVcOtlfW2rZEugt6w==",
           "dev": true,
           "requires": {
             "ansi-regex": "^5.0.0"
@@ -2723,8 +2723,8 @@
         },
         "supports-color": {
           "version": "7.1.0",
-          "resolved": "https://artifactory.corp.adobe.com:443/artifactory/api/npm/npmjs-remote/supports-color/-/supports-color-7.1.0.tgz",
-          "integrity": "sha1-aOMlkd9z4lrRxLSRCKLsUHliv9E=",
+          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.1.0.tgz",
+          "integrity": "sha512-oRSIpR8pxT1Wr2FquTNnGet79b3BWljqOuoW/h4oBhxJ/HUbX5nX6JSruTkvXDCFMwDPvsaTTbvMLKZWSy0R5g==",
           "dev": true,
           "requires": {
             "has-flag": "^4.0.0"
@@ -2732,8 +2732,8 @@
         },
         "type-fest": {
           "version": "0.11.0",
-          "resolved": "https://artifactory.corp.adobe.com:443/artifactory/api/npm/npmjs-remote/type-fest/-/type-fest-0.11.0.tgz",
-          "integrity": "sha1-l6vwhyMQ/tiKXEZrJWgVdhReM/E=",
+          "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-0.11.0.tgz",
+          "integrity": "sha512-OdjXJxnCN1AvyLSzeKIgXTXxV+99ZuXl3Hpo9XpJAv9MBcHrrJOQ5kV7ypXOuQie+AmWG25hLbiKdwYTifzcfQ==",
           "dev": true
         }
       }
@@ -2745,7 +2745,7 @@
     },
     "ip-regex": {
       "version": "2.1.0",
-      "resolved": "https://artifactory.corp.adobe.com:443/artifactory/api/npm/npmjs-remote/ip-regex/-/ip-regex-2.1.0.tgz",
+      "resolved": "https://registry.npmjs.org/ip-regex/-/ip-regex-2.1.0.tgz",
       "integrity": "sha1-+ni/XS5pE8kRzp+BnuUUa7bYROk="
     },
     "ipaddr.js": {
@@ -2755,7 +2755,7 @@
     },
     "is-accessor-descriptor": {
       "version": "0.1.6",
-      "resolved": "https://artifactory.corp.adobe.com:443/artifactory/api/npm/npmjs-remote/is-accessor-descriptor/-/is-accessor-descriptor-0.1.6.tgz",
+      "resolved": "https://registry.npmjs.org/is-accessor-descriptor/-/is-accessor-descriptor-0.1.6.tgz",
       "integrity": "sha1-qeEss66Nh2cn7u84Q/igiXtcmNY=",
       "requires": {
         "kind-of": "^3.0.2"
@@ -2763,7 +2763,7 @@
       "dependencies": {
         "kind-of": {
           "version": "3.2.2",
-          "resolved": "https://artifactory.corp.adobe.com:443/artifactory/api/npm/npmjs-remote/kind-of/-/kind-of-3.2.2.tgz",
+          "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
           "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
           "requires": {
             "is-buffer": "^1.1.5"
@@ -2792,7 +2792,7 @@
     },
     "is-data-descriptor": {
       "version": "0.1.4",
-      "resolved": "https://artifactory.corp.adobe.com:443/artifactory/api/npm/npmjs-remote/is-data-descriptor/-/is-data-descriptor-0.1.4.tgz",
+      "resolved": "https://registry.npmjs.org/is-data-descriptor/-/is-data-descriptor-0.1.4.tgz",
       "integrity": "sha1-C17mSDiOLIYCgueT8YVv7D8wG1Y=",
       "requires": {
         "kind-of": "^3.0.2"
@@ -2800,7 +2800,7 @@
       "dependencies": {
         "kind-of": {
           "version": "3.2.2",
-          "resolved": "https://artifactory.corp.adobe.com:443/artifactory/api/npm/npmjs-remote/kind-of/-/kind-of-3.2.2.tgz",
+          "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
           "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
           "requires": {
             "is-buffer": "^1.1.5"
@@ -2832,18 +2832,18 @@
     },
     "is-extendable": {
       "version": "0.1.1",
-      "resolved": "https://artifactory.corp.adobe.com:443/artifactory/api/npm/npmjs-remote/is-extendable/-/is-extendable-0.1.1.tgz",
+      "resolved": "https://registry.npmjs.org/is-extendable/-/is-extendable-0.1.1.tgz",
       "integrity": "sha1-YrEQ4omkcUGOPsNqYX1HLjAd/Ik="
     },
     "is-extglob": {
       "version": "2.1.1",
-      "resolved": "https://artifactory.corp.adobe.com:443/artifactory/api/npm/npmjs-remote/is-extglob/-/is-extglob-2.1.1.tgz",
+      "resolved": "https://registry.npmjs.org/is-extglob/-/is-extglob-2.1.1.tgz",
       "integrity": "sha1-qIwCU1eR8C7TfHahueqXc8gz+MI=",
       "dev": true
     },
     "is-fullwidth-code-point": {
       "version": "2.0.0",
-      "resolved": "https://artifactory.corp.adobe.com:443/artifactory/api/npm/npmjs-remote/is-fullwidth-code-point/-/is-fullwidth-code-point-2.0.0.tgz",
+      "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-2.0.0.tgz",
       "integrity": "sha1-o7MKXE8ZkYMWeqq5O+764937ZU8="
     },
     "is-glob": {
@@ -2857,7 +2857,7 @@
     },
     "is-number": {
       "version": "3.0.0",
-      "resolved": "https://artifactory.corp.adobe.com:443/artifactory/api/npm/npmjs-remote/is-number/-/is-number-3.0.0.tgz",
+      "resolved": "https://registry.npmjs.org/is-number/-/is-number-3.0.0.tgz",
       "integrity": "sha1-JP1iAaR4LPUFYcgQJ2r8fRLXEZU=",
       "requires": {
         "kind-of": "^3.0.2"
@@ -2865,7 +2865,7 @@
       "dependencies": {
         "kind-of": {
           "version": "3.2.2",
-          "resolved": "https://artifactory.corp.adobe.com:443/artifactory/api/npm/npmjs-remote/kind-of/-/kind-of-3.2.2.tgz",
+          "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
           "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
           "requires": {
             "is-buffer": "^1.1.5"
@@ -2895,13 +2895,13 @@
     },
     "is-stream": {
       "version": "1.1.0",
-      "resolved": "https://artifactory.corp.adobe.com:443/artifactory/api/npm/npmjs-remote/is-stream/-/is-stream-1.1.0.tgz",
+      "resolved": "https://registry.npmjs.org/is-stream/-/is-stream-1.1.0.tgz",
       "integrity": "sha1-EtSj3U5o4Lec6428hBc66A2RykQ=",
       "dev": true
     },
     "is-typedarray": {
       "version": "1.0.0",
-      "resolved": "https://artifactory.corp.adobe.com:443/artifactory/api/npm/npmjs-remote/is-typedarray/-/is-typedarray-1.0.0.tgz",
+      "resolved": "https://registry.npmjs.org/is-typedarray/-/is-typedarray-1.0.0.tgz",
       "integrity": "sha1-5HnICFjfDBsR3dppQPlgEfzaSpo="
     },
     "is-windows": {
@@ -2911,32 +2911,32 @@
     },
     "is-wsl": {
       "version": "1.1.0",
-      "resolved": "https://artifactory.corp.adobe.com:443/artifactory/api/npm/npmjs-remote/is-wsl/-/is-wsl-1.1.0.tgz",
+      "resolved": "https://registry.npmjs.org/is-wsl/-/is-wsl-1.1.0.tgz",
       "integrity": "sha1-HxbkqiKwTRM2tmGIpmrzxgDDpm0="
     },
     "isarray": {
       "version": "1.0.0",
-      "resolved": "https://artifactory.corp.adobe.com:443/artifactory/api/npm/npmjs-remote/isarray/-/isarray-1.0.0.tgz",
+      "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
       "integrity": "sha1-u5NdSFgsuhaMBoNJV6VKPgcSTxE="
     },
     "isexe": {
       "version": "2.0.0",
-      "resolved": "https://artifactory.corp.adobe.com:443/artifactory/api/npm/npmjs-remote/isexe/-/isexe-2.0.0.tgz",
+      "resolved": "https://registry.npmjs.org/isexe/-/isexe-2.0.0.tgz",
       "integrity": "sha1-6PvzdNxVb/iUehDcsFctYz8s+hA="
     },
     "isobject": {
       "version": "3.0.1",
-      "resolved": "https://artifactory.corp.adobe.com:443/artifactory/api/npm/npmjs-remote/isobject/-/isobject-3.0.1.tgz",
+      "resolved": "https://registry.npmjs.org/isobject/-/isobject-3.0.1.tgz",
       "integrity": "sha1-TkMekrEalzFjaqH5yNHMvP2reN8="
     },
     "isstream": {
       "version": "0.1.2",
-      "resolved": "https://artifactory.corp.adobe.com:443/artifactory/api/npm/npmjs-remote/isstream/-/isstream-0.1.2.tgz",
+      "resolved": "https://registry.npmjs.org/isstream/-/isstream-0.1.2.tgz",
       "integrity": "sha1-R+Y/evVa+m+S4VAOaQ64uFKcCZo="
     },
     "jmespath": {
       "version": "0.15.0",
-      "resolved": "https://artifactory.corp.adobe.com:443/artifactory/api/npm/npmjs-remote/jmespath/-/jmespath-0.15.0.tgz",
+      "resolved": "https://registry.npmjs.org/jmespath/-/jmespath-0.15.0.tgz",
       "integrity": "sha1-o/Iiqarp+Wb10nx5ZRDigJF2Qhc="
     },
     "js-tokens": {
@@ -2956,7 +2956,7 @@
     },
     "jsbn": {
       "version": "0.1.1",
-      "resolved": "https://artifactory.corp.adobe.com:443/artifactory/api/npm/npmjs-remote/jsbn/-/jsbn-0.1.1.tgz",
+      "resolved": "https://registry.npmjs.org/jsbn/-/jsbn-0.1.1.tgz",
       "integrity": "sha1-peZUwuWi3rXyAdls77yoDA7y9RM="
     },
     "json-parse-better-errors": {
@@ -2966,7 +2966,7 @@
     },
     "json-schema": {
       "version": "0.2.3",
-      "resolved": "https://artifactory.corp.adobe.com:443/artifactory/api/npm/npmjs-remote/json-schema/-/json-schema-0.2.3.tgz",
+      "resolved": "https://registry.npmjs.org/json-schema/-/json-schema-0.2.3.tgz",
       "integrity": "sha1-tIDIkuWaLwWVTOcnvT8qTogvnhM="
     },
     "json-schema-traverse": {
@@ -2976,18 +2976,18 @@
     },
     "json-stable-stringify-without-jsonify": {
       "version": "1.0.1",
-      "resolved": "https://artifactory.corp.adobe.com:443/artifactory/api/npm/npmjs-remote/json-stable-stringify-without-jsonify/-/json-stable-stringify-without-jsonify-1.0.1.tgz",
+      "resolved": "https://registry.npmjs.org/json-stable-stringify-without-jsonify/-/json-stable-stringify-without-jsonify-1.0.1.tgz",
       "integrity": "sha1-nbe1lJatPzz+8wp1FC0tkwrXJlE=",
       "dev": true
     },
     "json-stringify-safe": {
       "version": "5.0.1",
-      "resolved": "https://artifactory.corp.adobe.com:443/artifactory/api/npm/npmjs-remote/json-stringify-safe/-/json-stringify-safe-5.0.1.tgz",
+      "resolved": "https://registry.npmjs.org/json-stringify-safe/-/json-stringify-safe-5.0.1.tgz",
       "integrity": "sha1-Epai1Y/UXxmg9s4B1lcB4sc1tus="
     },
     "jsonfile": {
       "version": "4.0.0",
-      "resolved": "https://artifactory.corp.adobe.com:443/artifactory/api/npm/npmjs-remote/jsonfile/-/jsonfile-4.0.0.tgz",
+      "resolved": "https://registry.npmjs.org/jsonfile/-/jsonfile-4.0.0.tgz",
       "integrity": "sha1-h3Gq4HmbZAdrdmQPygWPnBDjPss=",
       "requires": {
         "graceful-fs": "^4.1.6"
@@ -3012,7 +3012,7 @@
     },
     "jsprim": {
       "version": "1.4.1",
-      "resolved": "https://artifactory.corp.adobe.com:443/artifactory/api/npm/npmjs-remote/jsprim/-/jsprim-1.4.1.tgz",
+      "resolved": "https://registry.npmjs.org/jsprim/-/jsprim-1.4.1.tgz",
       "integrity": "sha1-MT5mvB5cwG5Di8G3SZwuXFastqI=",
       "requires": {
         "assert-plus": "1.0.0",
@@ -3055,7 +3055,7 @@
     },
     "levn": {
       "version": "0.3.0",
-      "resolved": "https://artifactory.corp.adobe.com:443/artifactory/api/npm/npmjs-remote/levn/-/levn-0.3.0.tgz",
+      "resolved": "https://registry.npmjs.org/levn/-/levn-0.3.0.tgz",
       "integrity": "sha1-OwmSTt+fCDwEkP3UwLxEIeBHZO4=",
       "dev": true,
       "requires": {
@@ -3065,7 +3065,7 @@
     },
     "lines-and-columns": {
       "version": "1.1.6",
-      "resolved": "https://artifactory.corp.adobe.com:443/artifactory/api/npm/npmjs-remote/lines-and-columns/-/lines-and-columns-1.1.6.tgz",
+      "resolved": "https://registry.npmjs.org/lines-and-columns/-/lines-and-columns-1.1.6.tgz",
       "integrity": "sha1-HADHQ7QzzQpOgHWPe2SldEDZ/wA=",
       "dev": true
     },
@@ -3117,37 +3117,37 @@
     },
     "lodash._reinterpolate": {
       "version": "3.0.0",
-      "resolved": "https://artifactory.corp.adobe.com:443/artifactory/api/npm/npmjs-remote/lodash._reinterpolate/-/lodash._reinterpolate-3.0.0.tgz",
+      "resolved": "https://registry.npmjs.org/lodash._reinterpolate/-/lodash._reinterpolate-3.0.0.tgz",
       "integrity": "sha1-DM8tiRZq8Ds2Y8eWU4t1rG4RTZ0="
     },
     "lodash.clonedeep": {
       "version": "4.5.0",
-      "resolved": "https://artifactory.corp.adobe.com:443/artifactory/api/npm/npmjs-remote/lodash.clonedeep/-/lodash.clonedeep-4.5.0.tgz",
+      "resolved": "https://registry.npmjs.org/lodash.clonedeep/-/lodash.clonedeep-4.5.0.tgz",
       "integrity": "sha1-4j8/nE+Pvd6HJSnBBxhXoIblzO8="
     },
     "lodash.escaperegexp": {
       "version": "4.1.2",
-      "resolved": "https://artifactory.corp.adobe.com:443/artifactory/api/npm/npmjs-remote/lodash.escaperegexp/-/lodash.escaperegexp-4.1.2.tgz",
+      "resolved": "https://registry.npmjs.org/lodash.escaperegexp/-/lodash.escaperegexp-4.1.2.tgz",
       "integrity": "sha1-ZHYsSGGAglGKw99Mz11YhtriA0c="
     },
     "lodash.groupby": {
       "version": "4.6.0",
-      "resolved": "https://artifactory.corp.adobe.com:443/artifactory/api/npm/npmjs-remote/lodash.groupby/-/lodash.groupby-4.6.0.tgz",
+      "resolved": "https://registry.npmjs.org/lodash.groupby/-/lodash.groupby-4.6.0.tgz",
       "integrity": "sha1-Cwih3PaDl8OXhVwyOXg4Mt90A9E="
     },
     "lodash.includes": {
       "version": "4.3.0",
-      "resolved": "https://artifactory.corp.adobe.com:443/artifactory/api/npm/npmjs-remote/lodash.includes/-/lodash.includes-4.3.0.tgz",
+      "resolved": "https://registry.npmjs.org/lodash.includes/-/lodash.includes-4.3.0.tgz",
       "integrity": "sha1-YLuYqHy5I8aMoeUTJUgzFISfVT8="
     },
     "lodash.isboolean": {
       "version": "3.0.3",
-      "resolved": "https://artifactory.corp.adobe.com:443/artifactory/api/npm/npmjs-remote/lodash.isboolean/-/lodash.isboolean-3.0.3.tgz",
+      "resolved": "https://registry.npmjs.org/lodash.isboolean/-/lodash.isboolean-3.0.3.tgz",
       "integrity": "sha1-bC4XHbKiV82WgC/UOwGyDV9YcPY="
     },
     "lodash.isequal": {
       "version": "4.5.0",
-      "resolved": "https://artifactory.corp.adobe.com:443/artifactory/api/npm/npmjs-remote/lodash.isequal/-/lodash.isequal-4.5.0.tgz",
+      "resolved": "https://registry.npmjs.org/lodash.isequal/-/lodash.isequal-4.5.0.tgz",
       "integrity": "sha1-QVxEePK8wwEgwizhDtMib30+GOA="
     },
     "lodash.isfunction": {
@@ -3157,37 +3157,37 @@
     },
     "lodash.isinteger": {
       "version": "4.0.4",
-      "resolved": "https://artifactory.corp.adobe.com:443/artifactory/api/npm/npmjs-remote/lodash.isinteger/-/lodash.isinteger-4.0.4.tgz",
+      "resolved": "https://registry.npmjs.org/lodash.isinteger/-/lodash.isinteger-4.0.4.tgz",
       "integrity": "sha1-YZwK89A/iwTDH1iChAt3sRzWg0M="
     },
     "lodash.isnil": {
       "version": "4.0.0",
-      "resolved": "https://artifactory.corp.adobe.com:443/artifactory/api/npm/npmjs-remote/lodash.isnil/-/lodash.isnil-4.0.0.tgz",
+      "resolved": "https://registry.npmjs.org/lodash.isnil/-/lodash.isnil-4.0.0.tgz",
       "integrity": "sha1-SeKM1VkBNFjIFMVHnTxmOiG/qmw="
     },
     "lodash.isnumber": {
       "version": "3.0.3",
-      "resolved": "https://artifactory.corp.adobe.com:443/artifactory/api/npm/npmjs-remote/lodash.isnumber/-/lodash.isnumber-3.0.3.tgz",
+      "resolved": "https://registry.npmjs.org/lodash.isnumber/-/lodash.isnumber-3.0.3.tgz",
       "integrity": "sha1-POdoEMWSjQM1IwGsKHMX8RwLH/w="
     },
     "lodash.isplainobject": {
       "version": "4.0.6",
-      "resolved": "https://artifactory.corp.adobe.com:443/artifactory/api/npm/npmjs-remote/lodash.isplainobject/-/lodash.isplainobject-4.0.6.tgz",
+      "resolved": "https://registry.npmjs.org/lodash.isplainobject/-/lodash.isplainobject-4.0.6.tgz",
       "integrity": "sha1-fFJqUtibRcRcxpC4gWO+BJf1UMs="
     },
     "lodash.isstring": {
       "version": "4.0.1",
-      "resolved": "https://artifactory.corp.adobe.com:443/artifactory/api/npm/npmjs-remote/lodash.isstring/-/lodash.isstring-4.0.1.tgz",
+      "resolved": "https://registry.npmjs.org/lodash.isstring/-/lodash.isstring-4.0.1.tgz",
       "integrity": "sha1-1SfftUVuynzJu5XV2ur4i6VKVFE="
     },
     "lodash.isundefined": {
       "version": "3.0.1",
-      "resolved": "https://artifactory.corp.adobe.com:443/artifactory/api/npm/npmjs-remote/lodash.isundefined/-/lodash.isundefined-3.0.1.tgz",
+      "resolved": "https://registry.npmjs.org/lodash.isundefined/-/lodash.isundefined-3.0.1.tgz",
       "integrity": "sha1-I+89lTVWUgOmbO/VuDD4SJEa+0g="
     },
     "lodash.once": {
       "version": "4.1.1",
-      "resolved": "https://artifactory.corp.adobe.com:443/artifactory/api/npm/npmjs-remote/lodash.once/-/lodash.once-4.1.1.tgz",
+      "resolved": "https://registry.npmjs.org/lodash.once/-/lodash.once-4.1.1.tgz",
       "integrity": "sha1-DdOXEhPHxW34gJd9UEyI+0cal6w="
     },
     "lodash.template": {
@@ -3209,7 +3209,7 @@
     },
     "lodash.uniq": {
       "version": "4.5.0",
-      "resolved": "https://artifactory.corp.adobe.com:443/artifactory/api/npm/npmjs-remote/lodash.uniq/-/lodash.uniq-4.5.0.tgz",
+      "resolved": "https://registry.npmjs.org/lodash.uniq/-/lodash.uniq-4.5.0.tgz",
       "integrity": "sha1-0CJTc662Uq3BvILklFM5qEJ1R3M="
     },
     "make-dir": {
@@ -3231,12 +3231,12 @@
     },
     "map-cache": {
       "version": "0.2.2",
-      "resolved": "https://artifactory.corp.adobe.com:443/artifactory/api/npm/npmjs-remote/map-cache/-/map-cache-0.2.2.tgz",
+      "resolved": "https://registry.npmjs.org/map-cache/-/map-cache-0.2.2.tgz",
       "integrity": "sha1-wyq9C9ZSXZsFFkW7TyasXcmKDb8="
     },
     "map-visit": {
       "version": "1.0.0",
-      "resolved": "https://artifactory.corp.adobe.com:443/artifactory/api/npm/npmjs-remote/map-visit/-/map-visit-1.0.0.tgz",
+      "resolved": "https://registry.npmjs.org/map-visit/-/map-visit-1.0.0.tgz",
       "integrity": "sha1-7Nyo8TFE5mDxtb1B8S80edmN+48=",
       "requires": {
         "object-visit": "^1.0.0"
@@ -3244,12 +3244,12 @@
     },
     "media-typer": {
       "version": "0.3.0",
-      "resolved": "https://artifactory.corp.adobe.com:443/artifactory/api/npm/npmjs-remote/media-typer/-/media-typer-0.3.0.tgz",
+      "resolved": "https://registry.npmjs.org/media-typer/-/media-typer-0.3.0.tgz",
       "integrity": "sha1-hxDXrwqmJvj/+hzgAWhUUmMlV0g="
     },
     "merge-descriptors": {
       "version": "1.0.1",
-      "resolved": "https://artifactory.corp.adobe.com:443/artifactory/api/npm/npmjs-remote/merge-descriptors/-/merge-descriptors-1.0.1.tgz",
+      "resolved": "https://registry.npmjs.org/merge-descriptors/-/merge-descriptors-1.0.1.tgz",
       "integrity": "sha1-sAqqVW3YtEVoFQ7J0blT8/kMu2E="
     },
     "merge2": {
@@ -3260,13 +3260,13 @@
     },
     "methods": {
       "version": "1.1.2",
-      "resolved": "https://artifactory.corp.adobe.com:443/artifactory/api/npm/npmjs-remote/methods/-/methods-1.1.2.tgz",
+      "resolved": "https://registry.npmjs.org/methods/-/methods-1.1.2.tgz",
       "integrity": "sha1-VSmk1nZUE07cxSZmVoNbD4Ua/O4="
     },
     "metric-lcs": {
       "version": "0.1.2",
-      "resolved": "https://artifactory.corp.adobe.com:443/artifactory/api/npm/npmjs-remote/metric-lcs/-/metric-lcs-0.1.2.tgz",
-      "integrity": "sha1-h5E/FJQQ45x8WhkDdRKBTq8VXhE=",
+      "resolved": "https://registry.npmjs.org/metric-lcs/-/metric-lcs-0.1.2.tgz",
+      "integrity": "sha512-+TZ5dUDPKPJaU/rscTzxyN8ZkX7eAVLAiQU/e+YINleXPv03SCmJShaMT1If1liTH8OcmWXZs0CmzCBRBLcMpA==",
       "dev": true
     },
     "micromatch": {
@@ -3309,8 +3309,8 @@
     },
     "mimic-fn": {
       "version": "2.1.0",
-      "resolved": "https://artifactory.corp.adobe.com:443/artifactory/api/npm/npmjs-remote/mimic-fn/-/mimic-fn-2.1.0.tgz",
-      "integrity": "sha1-ftLCzMyvhNP/y3pptXcR/CCDQBs=",
+      "resolved": "https://registry.npmjs.org/mimic-fn/-/mimic-fn-2.1.0.tgz",
+      "integrity": "sha512-OqbOk5oEQeAZ8WXWydlu9HJjz9WVdEIvamMCcXmuqUYjTknH/sqsWvhQ3vgwKFRR1HpjvNBKQ37nbJgYzGqGcg==",
       "dev": true
     },
     "minimatch": {
@@ -3361,7 +3361,7 @@
     },
     "mock-stdin": {
       "version": "0.3.1",
-      "resolved": "https://artifactory.corp.adobe.com:443/artifactory/api/npm/npmjs-remote/mock-stdin/-/mock-stdin-0.3.1.tgz",
+      "resolved": "https://registry.npmjs.org/mock-stdin/-/mock-stdin-0.3.1.tgz",
       "integrity": "sha1-xlfZZC2QeGQ1xkyl6Zu9TQm9fdM=",
       "dev": true
     },
@@ -3372,8 +3372,8 @@
     },
     "mute-stream": {
       "version": "0.0.8",
-      "resolved": "https://artifactory.corp.adobe.com:443/artifactory/api/npm/npmjs-remote/mute-stream/-/mute-stream-0.0.8.tgz",
-      "integrity": "sha1-FjDEKyJR/4HiooPelqVJfqkuXg0=",
+      "resolved": "https://registry.npmjs.org/mute-stream/-/mute-stream-0.0.8.tgz",
+      "integrity": "sha512-nnbWWOkoWyUsTjKrhgD0dcz22mdkSnpYqbEjIm2nhwhuxlSkpywJmBo8h0ZqJdkp73mb90SssHkN4rsRaBAfAA==",
       "dev": true
     },
     "nanomatch": {
@@ -3396,7 +3396,7 @@
     },
     "natural-compare": {
       "version": "1.4.0",
-      "resolved": "https://artifactory.corp.adobe.com:443/artifactory/api/npm/npmjs-remote/natural-compare/-/natural-compare-1.4.0.tgz",
+      "resolved": "https://registry.npmjs.org/natural-compare/-/natural-compare-1.4.0.tgz",
       "integrity": "sha1-Sr6/7tdUHywnrPspvbvRXI1bpPc=",
       "dev": true
     },
@@ -3483,12 +3483,12 @@
     },
     "object-assign": {
       "version": "4.1.1",
-      "resolved": "https://artifactory.corp.adobe.com:443/artifactory/api/npm/npmjs-remote/object-assign/-/object-assign-4.1.1.tgz",
+      "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
       "integrity": "sha1-IQmtx5ZYh8/AXLvUQsrIv7s2CGM="
     },
     "object-copy": {
       "version": "0.1.0",
-      "resolved": "https://artifactory.corp.adobe.com:443/artifactory/api/npm/npmjs-remote/object-copy/-/object-copy-0.1.0.tgz",
+      "resolved": "https://registry.npmjs.org/object-copy/-/object-copy-0.1.0.tgz",
       "integrity": "sha1-fn2Fi3gb18mRpBupde04EnVOmYw=",
       "requires": {
         "copy-descriptor": "^0.1.0",
@@ -3498,7 +3498,7 @@
       "dependencies": {
         "define-property": {
           "version": "0.2.5",
-          "resolved": "https://artifactory.corp.adobe.com:443/artifactory/api/npm/npmjs-remote/define-property/-/define-property-0.2.5.tgz",
+          "resolved": "https://registry.npmjs.org/define-property/-/define-property-0.2.5.tgz",
           "integrity": "sha1-w1se+RjsPJkPmlvFe+BKrOxcgRY=",
           "requires": {
             "is-descriptor": "^0.1.0"
@@ -3506,7 +3506,7 @@
         },
         "kind-of": {
           "version": "3.2.2",
-          "resolved": "https://artifactory.corp.adobe.com:443/artifactory/api/npm/npmjs-remote/kind-of/-/kind-of-3.2.2.tgz",
+          "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
           "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
           "requires": {
             "is-buffer": "^1.1.5"
@@ -3521,7 +3521,7 @@
     },
     "object-visit": {
       "version": "1.0.1",
-      "resolved": "https://artifactory.corp.adobe.com:443/artifactory/api/npm/npmjs-remote/object-visit/-/object-visit-1.0.1.tgz",
+      "resolved": "https://registry.npmjs.org/object-visit/-/object-visit-1.0.1.tgz",
       "integrity": "sha1-95xEk68MU3e1n+OdOV5BBC3QRbs=",
       "requires": {
         "isobject": "^3.0.0"
@@ -3529,7 +3529,7 @@
     },
     "object.pick": {
       "version": "1.3.0",
-      "resolved": "https://artifactory.corp.adobe.com:443/artifactory/api/npm/npmjs-remote/object.pick/-/object.pick-1.3.0.tgz",
+      "resolved": "https://registry.npmjs.org/object.pick/-/object.pick-1.3.0.tgz",
       "integrity": "sha1-h6EKxMFpS9Lhy/U1kaZhQftd10c=",
       "requires": {
         "isobject": "^3.0.1"
@@ -3537,7 +3537,7 @@
     },
     "on-finished": {
       "version": "2.3.0",
-      "resolved": "https://artifactory.corp.adobe.com:443/artifactory/api/npm/npmjs-remote/on-finished/-/on-finished-2.3.0.tgz",
+      "resolved": "https://registry.npmjs.org/on-finished/-/on-finished-2.3.0.tgz",
       "integrity": "sha1-IPEzZIGwg811M3mSoWlxqi2QaUc=",
       "requires": {
         "ee-first": "1.1.1"
@@ -3545,7 +3545,7 @@
     },
     "once": {
       "version": "1.4.0",
-      "resolved": "https://artifactory.corp.adobe.com:443/artifactory/api/npm/npmjs-remote/once/-/once-1.4.0.tgz",
+      "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
       "integrity": "sha1-WDsap3WWHUsROsF9nFC6753Xa9E=",
       "requires": {
         "wrappy": "1"
@@ -3553,8 +3553,8 @@
     },
     "onetime": {
       "version": "5.1.0",
-      "resolved": "https://artifactory.corp.adobe.com:443/artifactory/api/npm/npmjs-remote/onetime/-/onetime-5.1.0.tgz",
-      "integrity": "sha1-//DzyRYX/mK7UBiWNumayKbfe+U=",
+      "resolved": "https://registry.npmjs.org/onetime/-/onetime-5.1.0.tgz",
+      "integrity": "sha512-5NcSkPHhwTVFIQN+TUqXoS5+dlElHXdpAWu9I0HP20YOtIi+aZ0Ct82jdlILDxjLEAWwvm+qj1m6aEtsDVmm6Q==",
       "dev": true,
       "requires": {
         "mimic-fn": "^2.1.0"
@@ -3594,8 +3594,8 @@
     },
     "optionator": {
       "version": "0.8.3",
-      "resolved": "https://artifactory.corp.adobe.com:443/artifactory/api/npm/npmjs-remote/optionator/-/optionator-0.8.3.tgz",
-      "integrity": "sha1-hPodA2/p08fiHZmIS2ARZ+yPtJU=",
+      "resolved": "https://registry.npmjs.org/optionator/-/optionator-0.8.3.tgz",
+      "integrity": "sha512-+IW9pACdk3XWmmTXG8m3upGUJst5XRGzxMRjXzAuJ1XnIFNvfhjjIuYkDvysnPQ7qzqVzLt78BCruntqRhWQbA==",
       "dev": true,
       "requires": {
         "deep-is": "~0.1.3",
@@ -3608,12 +3608,12 @@
     },
     "os-tmpdir": {
       "version": "1.0.2",
-      "resolved": "https://artifactory.corp.adobe.com:443/artifactory/api/npm/npmjs-remote/os-tmpdir/-/os-tmpdir-1.0.2.tgz",
+      "resolved": "https://registry.npmjs.org/os-tmpdir/-/os-tmpdir-1.0.2.tgz",
       "integrity": "sha1-u+Z0BseaqFxc/sdm/lc0VV36EnQ="
     },
     "p-finally": {
       "version": "1.0.0",
-      "resolved": "https://artifactory.corp.adobe.com:443/artifactory/api/npm/npmjs-remote/p-finally/-/p-finally-1.0.0.tgz",
+      "resolved": "https://registry.npmjs.org/p-finally/-/p-finally-1.0.0.tgz",
       "integrity": "sha1-P7z7FbiZpEEjs0ttzBi3JDNqLK4=",
       "dev": true
     },
@@ -3643,8 +3643,8 @@
     },
     "parent-module": {
       "version": "1.0.1",
-      "resolved": "https://artifactory.corp.adobe.com:443/artifactory/api/npm/npmjs-remote/parent-module/-/parent-module-1.0.1.tgz",
-      "integrity": "sha1-aR0nCeeMefrjoVZiJFLQB2LKqqI=",
+      "resolved": "https://registry.npmjs.org/parent-module/-/parent-module-1.0.1.tgz",
+      "integrity": "sha512-GQ2EWRpQV8/o+Aw8YqtfZZPfNRWZYkbidE9k5rpl/hC3vtHHBfGm2Ifi6qWV+coDGkrUKZAxE3Lot5kcsRlh+g==",
       "dev": true,
       "requires": {
         "callsites": "^3.0.0"
@@ -3652,7 +3652,7 @@
     },
     "parse-json": {
       "version": "4.0.0",
-      "resolved": "https://artifactory.corp.adobe.com:443/artifactory/api/npm/npmjs-remote/parse-json/-/parse-json-4.0.0.tgz",
+      "resolved": "https://registry.npmjs.org/parse-json/-/parse-json-4.0.0.tgz",
       "integrity": "sha1-vjX1Qlvh9/bHRxhPmKeIy5lHfuA=",
       "dev": true,
       "requires": {
@@ -3667,7 +3667,7 @@
     },
     "pascalcase": {
       "version": "0.1.1",
-      "resolved": "https://artifactory.corp.adobe.com:443/artifactory/api/npm/npmjs-remote/pascalcase/-/pascalcase-0.1.1.tgz",
+      "resolved": "https://registry.npmjs.org/pascalcase/-/pascalcase-0.1.1.tgz",
       "integrity": "sha1-s2PlXoAGym/iF4TS2yK9FdeRfxQ="
     },
     "password-prompt": {
@@ -3718,12 +3718,12 @@
     },
     "path-is-absolute": {
       "version": "1.0.1",
-      "resolved": "https://artifactory.corp.adobe.com:443/artifactory/api/npm/npmjs-remote/path-is-absolute/-/path-is-absolute-1.0.1.tgz",
+      "resolved": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.1.tgz",
       "integrity": "sha1-F0uSaHNVNP+8es5r9TpanhtcX18="
     },
     "path-key": {
       "version": "2.0.1",
-      "resolved": "https://artifactory.corp.adobe.com:443/artifactory/api/npm/npmjs-remote/path-key/-/path-key-2.0.1.tgz",
+      "resolved": "https://registry.npmjs.org/path-key/-/path-key-2.0.1.tgz",
       "integrity": "sha1-QRyttXTFoUDTpLGRDUDYDMn0C0A="
     },
     "path-parse": {
@@ -3734,7 +3734,7 @@
     },
     "path-to-regexp": {
       "version": "0.1.7",
-      "resolved": "https://artifactory.corp.adobe.com:443/artifactory/api/npm/npmjs-remote/path-to-regexp/-/path-to-regexp-0.1.7.tgz",
+      "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-0.1.7.tgz",
       "integrity": "sha1-32BBeABfUi8V60SQ5yR6G/qmf4w="
     },
     "path-type": {
@@ -3745,7 +3745,7 @@
     },
     "performance-now": {
       "version": "2.1.0",
-      "resolved": "https://artifactory.corp.adobe.com:443/artifactory/api/npm/npmjs-remote/performance-now/-/performance-now-2.1.0.tgz",
+      "resolved": "https://registry.npmjs.org/performance-now/-/performance-now-2.1.0.tgz",
       "integrity": "sha1-Ywn04OX6kT7BxpMHrjZLSzd8nns="
     },
     "picomatch": {
@@ -3765,19 +3765,19 @@
     },
     "posix-character-classes": {
       "version": "0.1.1",
-      "resolved": "https://artifactory.corp.adobe.com:443/artifactory/api/npm/npmjs-remote/posix-character-classes/-/posix-character-classes-0.1.1.tgz",
+      "resolved": "https://registry.npmjs.org/posix-character-classes/-/posix-character-classes-0.1.1.tgz",
       "integrity": "sha1-AerA/jta9xoqbAL+q7jB/vfgDqs="
     },
     "prelude-ls": {
       "version": "1.1.2",
-      "resolved": "https://artifactory.corp.adobe.com:443/artifactory/api/npm/npmjs-remote/prelude-ls/-/prelude-ls-1.1.2.tgz",
+      "resolved": "https://registry.npmjs.org/prelude-ls/-/prelude-ls-1.1.2.tgz",
       "integrity": "sha1-IZMqVJ9eUv/ZqCf1cOBL5iqX2lQ=",
       "dev": true
     },
     "progress": {
       "version": "2.0.3",
-      "resolved": "https://artifactory.corp.adobe.com:443/artifactory/api/npm/npmjs-remote/progress/-/progress-2.0.3.tgz",
-      "integrity": "sha1-foz42PW48jnBvGi+tOt4Vn1XLvg=",
+      "resolved": "https://registry.npmjs.org/progress/-/progress-2.0.3.tgz",
+      "integrity": "sha512-7PiHtLll5LdnKIMw100I+8xJXR5gW2QwWYkT6iJva0bXitZKa/XMrSbdmg3r2Xnaidz9Qumd0VPaMrZlF9V9sA==",
       "dev": true
     },
     "properties-reader": {
@@ -3906,13 +3906,13 @@
     },
     "querystring": {
       "version": "0.2.0",
-      "resolved": "https://artifactory.corp.adobe.com:443/artifactory/api/npm/npmjs-remote/querystring/-/querystring-0.2.0.tgz",
+      "resolved": "https://registry.npmjs.org/querystring/-/querystring-0.2.0.tgz",
       "integrity": "sha1-sgmEkgO7Jd+CDadW50cAWHhSFiA="
     },
     "ramda": {
       "version": "0.27.0",
-      "resolved": "https://artifactory.corp.adobe.com:443/artifactory/api/npm/npmjs-remote/ramda/-/ramda-0.27.0.tgz",
-      "integrity": "sha1-kV3CmGXAgAvz9puP1sJ5iYtZ3kM=",
+      "resolved": "https://registry.npmjs.org/ramda/-/ramda-0.27.0.tgz",
+      "integrity": "sha512-pVzZdDpWwWqEVVLshWUHjNwuVP7SfcmPraYuqocJp1yo2U1R7P+5QAfDhdItkuoGqIBnBYrtPp7rEPqDn9HlZA==",
       "dev": true
     },
     "range-parser": {
@@ -3963,7 +3963,7 @@
     },
     "redeyed": {
       "version": "2.1.1",
-      "resolved": "https://artifactory.corp.adobe.com:443/artifactory/api/npm/npmjs-remote/redeyed/-/redeyed-2.1.1.tgz",
+      "resolved": "https://registry.npmjs.org/redeyed/-/redeyed-2.1.1.tgz",
       "integrity": "sha1-iYS1gV2ZyyIEacme7v/jiRPmzAs=",
       "requires": {
         "esprima": "~4.0.0"
@@ -3980,8 +3980,8 @@
     },
     "regexpp": {
       "version": "2.0.1",
-      "resolved": "https://artifactory.corp.adobe.com:443/artifactory/api/npm/npmjs-remote/regexpp/-/regexpp-2.0.1.tgz",
-      "integrity": "sha1-jRnTHPYySCtYkEn4KB+T28uk0H8=",
+      "resolved": "https://registry.npmjs.org/regexpp/-/regexpp-2.0.1.tgz",
+      "integrity": "sha512-lv0M6+TkDVniA3aD1Eg0DVpfU/booSu7Eev3TDO/mZKHBfVjgCGTV4t4buppESEYDtkArYFOxTJWv6S5C+iaNw==",
       "dev": true
     },
     "repeat-element": {
@@ -3991,7 +3991,7 @@
     },
     "repeat-string": {
       "version": "1.6.1",
-      "resolved": "https://artifactory.corp.adobe.com:443/artifactory/api/npm/npmjs-remote/repeat-string/-/repeat-string-1.6.1.tgz",
+      "resolved": "https://registry.npmjs.org/repeat-string/-/repeat-string-1.6.1.tgz",
       "integrity": "sha1-jcrkcOHIirwtYA//Sndihtp15jc="
     },
     "request": {
@@ -4073,19 +4073,19 @@
     },
     "resolve-from": {
       "version": "4.0.0",
-      "resolved": "https://artifactory.corp.adobe.com:443/artifactory/api/npm/npmjs-remote/resolve-from/-/resolve-from-4.0.0.tgz",
-      "integrity": "sha1-SrzYUq0y3Xuqv+m0DgCjbbXzkuY=",
+      "resolved": "https://registry.npmjs.org/resolve-from/-/resolve-from-4.0.0.tgz",
+      "integrity": "sha512-pb/MYmXstAkysRFx8piNI1tGFNQIFA3vkE3Gq4EuA1dF6gHp/+vgZqsCGJapvy8N3Q+4o7FwvquPJcnZ7RYy4g==",
       "dev": true
     },
     "resolve-url": {
       "version": "0.2.1",
-      "resolved": "https://artifactory.corp.adobe.com:443/artifactory/api/npm/npmjs-remote/resolve-url/-/resolve-url-0.2.1.tgz",
+      "resolved": "https://registry.npmjs.org/resolve-url/-/resolve-url-0.2.1.tgz",
       "integrity": "sha1-LGN/53yJOv0qZj/iGqkIAGjiBSo="
     },
     "restore-cursor": {
       "version": "3.1.0",
-      "resolved": "https://artifactory.corp.adobe.com:443/artifactory/api/npm/npmjs-remote/restore-cursor/-/restore-cursor-3.1.0.tgz",
-      "integrity": "sha1-OfZ8VLOnpYzqUjbZXPADQjljH34=",
+      "resolved": "https://registry.npmjs.org/restore-cursor/-/restore-cursor-3.1.0.tgz",
+      "integrity": "sha512-l+sSefzHpj5qimhFSE5a8nufZYAM3sBSVMAPtYkmC+4EH2anSGaEMXSD0izRQbu9nfyQ9y5JrVmp7E8oZrUjvA==",
       "dev": true,
       "requires": {
         "onetime": "^5.1.0",
@@ -4133,8 +4133,8 @@
     },
     "run-async": {
       "version": "2.4.1",
-      "resolved": "https://artifactory.corp.adobe.com:443/artifactory/api/npm/npmjs-remote/run-async/-/run-async-2.4.1.tgz",
-      "integrity": "sha1-hEDsz5nqPnC9QJ1JqriOEMGJpFU=",
+      "resolved": "https://registry.npmjs.org/run-async/-/run-async-2.4.1.tgz",
+      "integrity": "sha512-tvVnVv01b8c1RrA6Ep7JkStj85Guv/YrMcwqYQnwjsAS2cTmmPGBBjAjpCW7RrSodNSoE2/qg9O4bceNvUuDgQ==",
       "dev": true
     },
     "run-parallel": {
@@ -4145,8 +4145,8 @@
     },
     "rxjs": {
       "version": "6.5.5",
-      "resolved": "https://artifactory.corp.adobe.com:443/artifactory/api/npm/npmjs-remote/rxjs/-/rxjs-6.5.5.tgz",
-      "integrity": "sha1-xciE4wlMjP7jG/J+uH5UzPyH+ew=",
+      "resolved": "https://registry.npmjs.org/rxjs/-/rxjs-6.5.5.tgz",
+      "integrity": "sha512-WfQI+1gohdf0Dai/Bbmk5L5ItH5tYqm3ki2c5GdWhKjalzjg93N3avFjVStyZZz+A2Em+ZxKH5bNghw9UeylGQ==",
       "dev": true,
       "requires": {
         "tslib": "^1.9.0"
@@ -4159,7 +4159,7 @@
     },
     "safe-regex": {
       "version": "1.1.0",
-      "resolved": "https://artifactory.corp.adobe.com:443/artifactory/api/npm/npmjs-remote/safe-regex/-/safe-regex-1.1.0.tgz",
+      "resolved": "https://registry.npmjs.org/safe-regex/-/safe-regex-1.1.0.tgz",
       "integrity": "sha1-QKNmnzsHfR6UPURinhV91IAjvy4=",
       "requires": {
         "ret": "~0.1.10"
@@ -4182,7 +4182,7 @@
     },
     "semver-compare": {
       "version": "1.0.0",
-      "resolved": "https://artifactory.corp.adobe.com:443/artifactory/api/npm/npmjs-remote/semver-compare/-/semver-compare-1.0.0.tgz",
+      "resolved": "https://registry.npmjs.org/semver-compare/-/semver-compare-1.0.0.tgz",
       "integrity": "sha1-De4hahyUGrN+nvsXiPavxf9VN/w="
     },
     "send": {
@@ -4266,7 +4266,7 @@
     },
     "sha1": {
       "version": "1.1.1",
-      "resolved": "https://artifactory.corp.adobe.com:443/artifactory/api/npm/npmjs-remote/sha1/-/sha1-1.1.1.tgz",
+      "resolved": "https://registry.npmjs.org/sha1/-/sha1-1.1.1.tgz",
       "integrity": "sha1-rdqnqTFo85PxnrKxUJFhjicA+Eg=",
       "requires": {
         "charenc": ">= 0.0.1",
@@ -4275,7 +4275,7 @@
     },
     "shebang-command": {
       "version": "1.2.0",
-      "resolved": "https://artifactory.corp.adobe.com:443/artifactory/api/npm/npmjs-remote/shebang-command/-/shebang-command-1.2.0.tgz",
+      "resolved": "https://registry.npmjs.org/shebang-command/-/shebang-command-1.2.0.tgz",
       "integrity": "sha1-RKrGW2lbAzmJaMOfNj/uXer98eo=",
       "requires": {
         "shebang-regex": "^1.0.0"
@@ -4283,7 +4283,7 @@
     },
     "shebang-regex": {
       "version": "1.0.0",
-      "resolved": "https://artifactory.corp.adobe.com:443/artifactory/api/npm/npmjs-remote/shebang-regex/-/shebang-regex-1.0.0.tgz",
+      "resolved": "https://registry.npmjs.org/shebang-regex/-/shebang-regex-1.0.0.tgz",
       "integrity": "sha1-2kL0l0DAtC2yypcoVxyxkMmO/qM="
     },
     "signal-exit": {
@@ -4299,8 +4299,8 @@
     },
     "slice-ansi": {
       "version": "2.1.0",
-      "resolved": "https://artifactory.corp.adobe.com:443/artifactory/api/npm/npmjs-remote/slice-ansi/-/slice-ansi-2.1.0.tgz",
-      "integrity": "sha1-ys12k0YaY3pXiNkqfdT7oGjoFjY=",
+      "resolved": "https://registry.npmjs.org/slice-ansi/-/slice-ansi-2.1.0.tgz",
+      "integrity": "sha512-Qu+VC3EwYLldKa1fCxuuvULvSJOKEgk9pi8dZeCVK7TqBfUNTH4sFkk4joj8afVSfAYgJoSOetjx9QWOJ5mYoQ==",
       "dev": true,
       "requires": {
         "ansi-styles": "^3.2.0",
@@ -4429,7 +4429,7 @@
     },
     "source-map": {
       "version": "0.5.7",
-      "resolved": "https://artifactory.corp.adobe.com:443/artifactory/api/npm/npmjs-remote/source-map/-/source-map-0.5.7.tgz",
+      "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.5.7.tgz",
       "integrity": "sha1-igOdLRAh0i0eoUyA2OpGi6LvP8w="
     },
     "source-map-resolve": {
@@ -4446,7 +4446,7 @@
     },
     "source-map-url": {
       "version": "0.4.0",
-      "resolved": "https://artifactory.corp.adobe.com:443/artifactory/api/npm/npmjs-remote/source-map-url/-/source-map-url-0.4.0.tgz",
+      "resolved": "https://registry.npmjs.org/source-map-url/-/source-map-url-0.4.0.tgz",
       "integrity": "sha1-PpNdfd1zYxuXZZlW1VEo6HtQhKM="
     },
     "spdx-correct": {
@@ -4491,7 +4491,7 @@
     },
     "sprintf-js": {
       "version": "1.0.3",
-      "resolved": "https://artifactory.corp.adobe.com:443/artifactory/api/npm/npmjs-remote/sprintf-js/-/sprintf-js-1.0.3.tgz",
+      "resolved": "https://registry.npmjs.org/sprintf-js/-/sprintf-js-1.0.3.tgz",
       "integrity": "sha1-BOaSb2YolTVPPdAVIDYzuFcpfiw="
     },
     "sshpk": {
@@ -4512,7 +4512,7 @@
     },
     "static-extend": {
       "version": "0.1.2",
-      "resolved": "https://artifactory.corp.adobe.com:443/artifactory/api/npm/npmjs-remote/static-extend/-/static-extend-0.1.2.tgz",
+      "resolved": "https://registry.npmjs.org/static-extend/-/static-extend-0.1.2.tgz",
       "integrity": "sha1-YICcOcv/VTNyJv1eC1IPNB8ftcY=",
       "requires": {
         "define-property": "^0.2.5",
@@ -4521,7 +4521,7 @@
       "dependencies": {
         "define-property": {
           "version": "0.2.5",
-          "resolved": "https://artifactory.corp.adobe.com:443/artifactory/api/npm/npmjs-remote/define-property/-/define-property-0.2.5.tgz",
+          "resolved": "https://registry.npmjs.org/define-property/-/define-property-0.2.5.tgz",
           "integrity": "sha1-w1se+RjsPJkPmlvFe+BKrOxcgRY=",
           "requires": {
             "is-descriptor": "^0.1.0"
@@ -4531,7 +4531,7 @@
     },
     "statuses": {
       "version": "1.5.0",
-      "resolved": "https://artifactory.corp.adobe.com:443/artifactory/api/npm/npmjs-remote/statuses/-/statuses-1.5.0.tgz",
+      "resolved": "https://registry.npmjs.org/statuses/-/statuses-1.5.0.tgz",
       "integrity": "sha1-Fhx9rBd2Wf2YEfQ3cfqZOBR4Yow="
     },
     "stdout-stderr": {
@@ -4610,14 +4610,14 @@
     },
     "strip-eof": {
       "version": "1.0.0",
-      "resolved": "https://artifactory.corp.adobe.com:443/artifactory/api/npm/npmjs-remote/strip-eof/-/strip-eof-1.0.0.tgz",
+      "resolved": "https://registry.npmjs.org/strip-eof/-/strip-eof-1.0.0.tgz",
       "integrity": "sha1-u0P/VZim6wXYm1n80SnJgzE2Br8=",
       "dev": true
     },
     "strip-json-comments": {
       "version": "3.1.0",
-      "resolved": "https://artifactory.corp.adobe.com:443/artifactory/api/npm/npmjs-remote/strip-json-comments/-/strip-json-comments-3.1.0.tgz",
-      "integrity": "sha1-djjTFCISns9EV0QACfugP5+awYA=",
+      "resolved": "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-3.1.0.tgz",
+      "integrity": "sha512-e6/d0eBu7gHtdCqFt0xJr642LdToM5/cN4Qb9DbHjVx1CP5RyeM+zH7pbecEmDv/lBqb0QH+6Uqq75rxFPkM0w==",
       "dev": true
     },
     "supports-color": {
@@ -4646,8 +4646,8 @@
     },
     "table": {
       "version": "5.4.6",
-      "resolved": "https://artifactory.corp.adobe.com:443/artifactory/api/npm/npmjs-remote/table/-/table-5.4.6.tgz",
-      "integrity": "sha1-EpLRlQDOP4YFOwXw6Ofko7shB54=",
+      "resolved": "https://registry.npmjs.org/table/-/table-5.4.6.tgz",
+      "integrity": "sha512-wmEc8m4fjnob4gt5riFRtTu/6+4rSe12TpAELNSqHMfF3IqnA+CH37USM6/YR3qRZv7e56kAEAtd6nKZaxe0Ug==",
       "dev": true,
       "requires": {
         "ajv": "^6.10.2",
@@ -4658,8 +4658,8 @@
       "dependencies": {
         "string-width": {
           "version": "3.1.0",
-          "resolved": "https://artifactory.corp.adobe.com:443/artifactory/api/npm/npmjs-remote/string-width/-/string-width-3.1.0.tgz",
-          "integrity": "sha1-InZ74htirxCBV0MG9prFG2IgOWE=",
+          "resolved": "https://registry.npmjs.org/string-width/-/string-width-3.1.0.tgz",
+          "integrity": "sha512-vafcv6KjVZKSgz06oM/H6GDBrAtz8vdhQakGjFIvNrHA6y3HCF1CInLy+QLq8dTJPQ1b+KDUqDFctkdRW44e1w==",
           "dev": true,
           "requires": {
             "emoji-regex": "^7.0.1",
@@ -4696,13 +4696,13 @@
     },
     "text-table": {
       "version": "0.2.0",
-      "resolved": "https://artifactory.corp.adobe.com:443/artifactory/api/npm/npmjs-remote/text-table/-/text-table-0.2.0.tgz",
+      "resolved": "https://registry.npmjs.org/text-table/-/text-table-0.2.0.tgz",
       "integrity": "sha1-f17oI66AUgfACvLfSoTsP8+lcLQ=",
       "dev": true
     },
     "through": {
       "version": "2.3.8",
-      "resolved": "https://artifactory.corp.adobe.com:443/artifactory/api/npm/npmjs-remote/through/-/through-2.3.8.tgz",
+      "resolved": "https://registry.npmjs.org/through/-/through-2.3.8.tgz",
       "integrity": "sha1-DdTJ/6q8NXlgsbckEV1+Doai4fU=",
       "dev": true
     },
@@ -4716,7 +4716,7 @@
     },
     "to-object-path": {
       "version": "0.3.0",
-      "resolved": "https://artifactory.corp.adobe.com:443/artifactory/api/npm/npmjs-remote/to-object-path/-/to-object-path-0.3.0.tgz",
+      "resolved": "https://registry.npmjs.org/to-object-path/-/to-object-path-0.3.0.tgz",
       "integrity": "sha1-KXWIt7Dn4KwI4E5nL4XB9JmeF68=",
       "requires": {
         "kind-of": "^3.0.2"
@@ -4724,7 +4724,7 @@
       "dependencies": {
         "kind-of": {
           "version": "3.2.2",
-          "resolved": "https://artifactory.corp.adobe.com:443/artifactory/api/npm/npmjs-remote/kind-of/-/kind-of-3.2.2.tgz",
+          "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
           "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
           "requires": {
             "is-buffer": "^1.1.5"
@@ -4745,7 +4745,7 @@
     },
     "to-regex-range": {
       "version": "2.1.1",
-      "resolved": "https://artifactory.corp.adobe.com:443/artifactory/api/npm/npmjs-remote/to-regex-range/-/to-regex-range-2.1.1.tgz",
+      "resolved": "https://registry.npmjs.org/to-regex-range/-/to-regex-range-2.1.1.tgz",
       "integrity": "sha1-fIDBe53+vlmeJzZ+DU3VWQFB2zg=",
       "requires": {
         "is-number": "^3.0.0",
@@ -4784,7 +4784,7 @@
     },
     "tunnel-agent": {
       "version": "0.6.0",
-      "resolved": "https://artifactory.corp.adobe.com:443/artifactory/api/npm/npmjs-remote/tunnel-agent/-/tunnel-agent-0.6.0.tgz",
+      "resolved": "https://registry.npmjs.org/tunnel-agent/-/tunnel-agent-0.6.0.tgz",
       "integrity": "sha1-J6XeoGs2sEoKmWZ3SykIaPD8QP0=",
       "requires": {
         "safe-buffer": "^5.0.1"
@@ -4792,12 +4792,12 @@
     },
     "tweetnacl": {
       "version": "0.14.5",
-      "resolved": "https://artifactory.corp.adobe.com:443/artifactory/api/npm/npmjs-remote/tweetnacl/-/tweetnacl-0.14.5.tgz",
+      "resolved": "https://registry.npmjs.org/tweetnacl/-/tweetnacl-0.14.5.tgz",
       "integrity": "sha1-WuaBd/GS1EViadEIr6k/+HQ/T2Q="
     },
     "type-check": {
       "version": "0.3.2",
-      "resolved": "https://artifactory.corp.adobe.com:443/artifactory/api/npm/npmjs-remote/type-check/-/type-check-0.3.2.tgz",
+      "resolved": "https://registry.npmjs.org/type-check/-/type-check-0.3.2.tgz",
       "integrity": "sha1-WITKtRLPHTVeP7eE8wgEsrUg23I=",
       "dev": true,
       "requires": {
@@ -4806,8 +4806,8 @@
     },
     "type-fest": {
       "version": "0.8.1",
-      "resolved": "https://artifactory.corp.adobe.com:443/artifactory/api/npm/npmjs-remote/type-fest/-/type-fest-0.8.1.tgz",
-      "integrity": "sha1-CeJJ696FHTseSNJ8EFREZn8XuD0=",
+      "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-0.8.1.tgz",
+      "integrity": "sha512-4dbzIzqvjtgiM5rw1k5rEHtBANKmdudhGyBEajN01fEyhaAIhsoKNy6y7+IN93IfpFtwY9iqi7kD+xwKhQsNJA==",
       "dev": true
     },
     "type-is": {
@@ -4846,12 +4846,12 @@
     },
     "unpipe": {
       "version": "1.0.0",
-      "resolved": "https://artifactory.corp.adobe.com:443/artifactory/api/npm/npmjs-remote/unpipe/-/unpipe-1.0.0.tgz",
+      "resolved": "https://registry.npmjs.org/unpipe/-/unpipe-1.0.0.tgz",
       "integrity": "sha1-sr9O6FFKrmFltIF4KdIbLvSZBOw="
     },
     "unset-value": {
       "version": "1.0.0",
-      "resolved": "https://artifactory.corp.adobe.com:443/artifactory/api/npm/npmjs-remote/unset-value/-/unset-value-1.0.0.tgz",
+      "resolved": "https://registry.npmjs.org/unset-value/-/unset-value-1.0.0.tgz",
       "integrity": "sha1-g3aHP30jNRef+x5vw6jtDfyKtVk=",
       "requires": {
         "has-value": "^0.3.1",
@@ -4860,7 +4860,7 @@
       "dependencies": {
         "has-value": {
           "version": "0.3.1",
-          "resolved": "https://artifactory.corp.adobe.com:443/artifactory/api/npm/npmjs-remote/has-value/-/has-value-0.3.1.tgz",
+          "resolved": "https://registry.npmjs.org/has-value/-/has-value-0.3.1.tgz",
           "integrity": "sha1-ex9YutpiyoJ+wKIHgCVlSEWZXh8=",
           "requires": {
             "get-value": "^2.0.3",
@@ -4870,7 +4870,7 @@
           "dependencies": {
             "isobject": {
               "version": "2.1.0",
-              "resolved": "https://artifactory.corp.adobe.com:443/artifactory/api/npm/npmjs-remote/isobject/-/isobject-2.1.0.tgz",
+              "resolved": "https://registry.npmjs.org/isobject/-/isobject-2.1.0.tgz",
               "integrity": "sha1-8GVWEJaj8dou9GJy+BXIQNh+DIk=",
               "requires": {
                 "isarray": "1.0.0"
@@ -4880,7 +4880,7 @@
         },
         "has-values": {
           "version": "0.1.4",
-          "resolved": "https://artifactory.corp.adobe.com:443/artifactory/api/npm/npmjs-remote/has-values/-/has-values-0.1.4.tgz",
+          "resolved": "https://registry.npmjs.org/has-values/-/has-values-0.1.4.tgz",
           "integrity": "sha1-bWHeldkd/Km5oCCJrThL/49it3E="
         }
       }
@@ -4895,12 +4895,12 @@
     },
     "urix": {
       "version": "0.1.0",
-      "resolved": "https://artifactory.corp.adobe.com:443/artifactory/api/npm/npmjs-remote/urix/-/urix-0.1.0.tgz",
+      "resolved": "https://registry.npmjs.org/urix/-/urix-0.1.0.tgz",
       "integrity": "sha1-2pN/emLiH+wf0Y1Js1wpNQZ6bHI="
     },
     "url": {
       "version": "0.10.3",
-      "resolved": "https://artifactory.corp.adobe.com:443/artifactory/api/npm/npmjs-remote/url/-/url-0.10.3.tgz",
+      "resolved": "https://registry.npmjs.org/url/-/url-0.10.3.tgz",
       "integrity": "sha1-Ah5NnHcF8hu/N9A861h2dAJ3TGQ=",
       "requires": {
         "punycode": "1.3.2",
@@ -4909,7 +4909,7 @@
       "dependencies": {
         "punycode": {
           "version": "1.3.2",
-          "resolved": "https://artifactory.corp.adobe.com:443/artifactory/api/npm/npmjs-remote/punycode/-/punycode-1.3.2.tgz",
+          "resolved": "https://registry.npmjs.org/punycode/-/punycode-1.3.2.tgz",
           "integrity": "sha1-llOgNvt8HuQjQvIyXM7v6jkmxI0="
         }
       }
@@ -4921,13 +4921,13 @@
     },
     "util-deprecate": {
       "version": "1.0.2",
-      "resolved": "https://artifactory.corp.adobe.com:443/artifactory/api/npm/npmjs-remote/util-deprecate/-/util-deprecate-1.0.2.tgz",
+      "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
       "integrity": "sha1-RQ1Nyfpw3nMnYvvS1KKJgUGaDM8=",
       "dev": true
     },
     "utils-merge": {
       "version": "1.0.1",
-      "resolved": "https://artifactory.corp.adobe.com:443/artifactory/api/npm/npmjs-remote/utils-merge/-/utils-merge-1.0.1.tgz",
+      "resolved": "https://registry.npmjs.org/utils-merge/-/utils-merge-1.0.1.tgz",
       "integrity": "sha1-n5VxD1CiZ5R7LMwSR0HBAoQn5xM="
     },
     "uuid": {
@@ -4937,13 +4937,13 @@
     },
     "v8-compile-cache": {
       "version": "2.1.0",
-      "resolved": "https://artifactory.corp.adobe.com:443/artifactory/api/npm/npmjs-remote/v8-compile-cache/-/v8-compile-cache-2.1.0.tgz",
-      "integrity": "sha1-4U3jezGm0ZT1aQ1n78Tn9vxqsw4=",
+      "resolved": "https://registry.npmjs.org/v8-compile-cache/-/v8-compile-cache-2.1.0.tgz",
+      "integrity": "sha512-usZBT3PW+LOjM25wbqIlZwPeJV+3OSz3M1k1Ws8snlW39dZyYL9lOGC5FgPVHfk0jKmjiDV8Z0mIbVQPiwFs7g==",
       "dev": true
     },
     "valid-url": {
       "version": "1.0.9",
-      "resolved": "https://artifactory.corp.adobe.com:443/artifactory/api/npm/npmjs-remote/valid-url/-/valid-url-1.0.9.tgz",
+      "resolved": "https://registry.npmjs.org/valid-url/-/valid-url-1.0.9.tgz",
       "integrity": "sha1-HBRHm0DxOXp1eC8RXkCGRHQzogA="
     },
     "validate-npm-package-license": {
@@ -4958,12 +4958,12 @@
     },
     "vary": {
       "version": "1.1.2",
-      "resolved": "https://artifactory.corp.adobe.com:443/artifactory/api/npm/npmjs-remote/vary/-/vary-1.1.2.tgz",
+      "resolved": "https://registry.npmjs.org/vary/-/vary-1.1.2.tgz",
       "integrity": "sha1-IpnwLG3tMNSllhsLn3RSShj2NPw="
     },
     "verror": {
       "version": "1.10.0",
-      "resolved": "https://artifactory.corp.adobe.com:443/artifactory/api/npm/npmjs-remote/verror/-/verror-1.10.0.tgz",
+      "resolved": "https://registry.npmjs.org/verror/-/verror-1.10.0.tgz",
       "integrity": "sha1-OhBcoXBTr1XW4nDB+CiGguGNpAA=",
       "requires": {
         "assert-plus": "^1.0.0",
@@ -4973,7 +4973,7 @@
     },
     "when": {
       "version": "3.7.8",
-      "resolved": "https://artifactory.corp.adobe.com:443/artifactory/api/npm/npmjs-remote/when/-/when-3.7.8.tgz",
+      "resolved": "https://registry.npmjs.org/when/-/when-3.7.8.tgz",
       "integrity": "sha1-xxMLan6gRpPoQs3J56Hyqjmjn4I="
     },
     "which": {
@@ -4994,8 +4994,8 @@
     },
     "word-wrap": {
       "version": "1.2.3",
-      "resolved": "https://artifactory.corp.adobe.com:443/artifactory/api/npm/npmjs-remote/word-wrap/-/word-wrap-1.2.3.tgz",
-      "integrity": "sha1-YQY29rH3A4kb00dxzLF/uTtHB5w=",
+      "resolved": "https://registry.npmjs.org/word-wrap/-/word-wrap-1.2.3.tgz",
+      "integrity": "sha512-Hz/mrNwitNRh/HUAtM/VT/5VH+ygD6DV7mYKZAtHOrbs8U7lvPS6xf7EJKMF0uW1KJCl0H701g3ZGus+muE5vQ==",
       "dev": true
     },
     "wrap-ansi": {
@@ -5025,13 +5025,13 @@
     },
     "wrappy": {
       "version": "1.0.2",
-      "resolved": "https://artifactory.corp.adobe.com:443/artifactory/api/npm/npmjs-remote/wrappy/-/wrappy-1.0.2.tgz",
+      "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
       "integrity": "sha1-tSQ9jz7BqjXxNkYFvA0QNuMKtp8="
     },
     "write": {
       "version": "1.0.3",
-      "resolved": "https://artifactory.corp.adobe.com:443/artifactory/api/npm/npmjs-remote/write/-/write-1.0.3.tgz",
-      "integrity": "sha1-CADhRSO5I6OH5BUSPIZWFqrg9cM=",
+      "resolved": "https://registry.npmjs.org/write/-/write-1.0.3.tgz",
+      "integrity": "sha512-/lg70HAjtkUgWPVZhZcm+T4hkL8Zbtp1nFNOn3lRrxnlv50SRBv7cR7RqR+GMsd3hUXy9hWBo4CHTbFTcOYwig==",
       "dev": true,
       "requires": {
         "mkdirp": "^0.5.1"
@@ -5065,7 +5065,7 @@
     },
     "xml": {
       "version": "1.0.1",
-      "resolved": "https://artifactory.corp.adobe.com:443/artifactory/api/npm/npmjs-remote/xml/-/xml-1.0.1.tgz",
+      "resolved": "https://registry.npmjs.org/xml/-/xml-1.0.1.tgz",
       "integrity": "sha1-eLpyAgApxbyHuKgaPPzXS0ovweU="
     },
     "xml2js": {

--- a/package.json
+++ b/package.json
@@ -25,7 +25,7 @@
     "xml": "^1.0.1"
   },
   "devDependencies": {
-    "@adobe/eslint-config-asset-compute": "^1.2.0",
+    "@adobe/eslint-config-asset-compute": "^1.3.0",
     "@oclif/dev-cli": "^1.22.2",
     "@oclif/test": "^1.2.5",
     "globby": "^11.0.0"

--- a/src/base-command.js
+++ b/src/base-command.js
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019 Adobe Inc. All rights reserved.
+ * Copyright 2019 Adobe. All rights reserved.
  * This file is licensed to you under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License. You may obtain a copy
  * of the License at http://www.apache.org/licenses/LICENSE-2.0

--- a/src/commands/asset-compute/devtool.js
+++ b/src/commands/asset-compute/devtool.js
@@ -1,14 +1,14 @@
 /*
-Copyright 2020 Adobe. All rights reserved.
-This file is licensed to you under the Apache License, Version 2.0 (the "License");
-you may not use this file except in compliance with the License. You may obtain a copy
-of the License at http://www.apache.org/licenses/LICENSE-2.0
-
-Unless required by applicable law or agreed to in writing, software distributed under
-the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
-OF ANY KIND, either express or implied. See the License for the specific language
-governing permissions and limitations under the License.
-*/
+ * Copyright 2020 Adobe. All rights reserved.
+ * This file is licensed to you under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License. You may obtain a copy
+ * of the License at http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under
+ * the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
+ * OF ANY KIND, either express or implied. See the License for the specific language
+ * governing permissions and limitations under the License.
+ */
 
 'use strict';
 

--- a/src/commands/asset-compute/run-worker.js
+++ b/src/commands/asset-compute/run-worker.js
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019 Adobe Inc. All rights reserved.
+ * Copyright 2019 Adobe. All rights reserved.
  * This file is licensed to you under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License. You may obtain a copy
  * of the License at http://www.apache.org/licenses/LICENSE-2.0

--- a/src/commands/asset-compute/test-worker.js
+++ b/src/commands/asset-compute/test-worker.js
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019 Adobe Inc. All rights reserved.
+ * Copyright 2019 Adobe. All rights reserved.
  * This file is licensed to you under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License. You may obtain a copy
  * of the License at http://www.apache.org/licenses/LICENSE-2.0

--- a/src/lib/actionrunner.js
+++ b/src/lib/actionrunner.js
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019 Adobe Inc. All rights reserved.
+ * Copyright 2019 Adobe. All rights reserved.
  * This file is licensed to you under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License. You may obtain a copy
  * of the License at http://www.apache.org/licenses/LICENSE-2.0
@@ -341,7 +341,7 @@ class OpenwhiskActionRunner {
             proc.stdout.removeAllListeners("data");
             proc.stderr.removeAllListeners("data");
             kill.apply(proc);
-        }
+        };
 
         return proc;
     }

--- a/src/lib/cloudfiles.js
+++ b/src/lib/cloudfiles.js
@@ -1,14 +1,14 @@
 /*
-Copyright 2020 Adobe. All rights reserved.
-This file is licensed to you under the Apache License, Version 2.0 (the "License");
-you may not use this file except in compliance with the License. You may obtain a copy
-of the License at http://www.apache.org/licenses/LICENSE-2.0
-
-Unless required by applicable law or agreed to in writing, software distributed under
-the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
-OF ANY KIND, either express or implied. See the License for the specific language
-governing permissions and limitations under the License.
-*/
+ * Copyright 2020 Adobe. All rights reserved.
+ * This file is licensed to you under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License. You may obtain a copy
+ * of the License at http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under
+ * the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
+ * OF ANY KIND, either express or implied. See the License for the specific language
+ * governing permissions and limitations under the License.
+ */
 
 'use strict';
 

--- a/src/lib/mockserver.js
+++ b/src/lib/mockserver.js
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019 Adobe Inc. All rights reserved.
+ * Copyright 2019 Adobe. All rights reserved.
  * This file is licensed to you under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License. You may obtain a copy
  * of the License at http://www.apache.org/licenses/LICENSE-2.0
@@ -21,7 +21,7 @@ const MOCK_SERVER_IMAGE = 'mockserver/mockserver:mockserver-5.8.1';
 
 // "mock-upload.wikimedia.org.json" => "upload.wikimedia.org"
 function getHostName(file) {
-    file = path.basename(file, path.extname(file))
+    file = path.basename(file, path.extname(file));
     if (file.startsWith("mock-")) {
         file = file.substring("mock-".length);
     }

--- a/src/lib/testresults.js
+++ b/src/lib/testresults.js
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019 Adobe Inc. All rights reserved.
+ * Copyright 2019 Adobe. All rights reserved.
  * This file is licensed to you under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License. You may obtain a copy
  * of the License at http://www.apache.org/licenses/LICENSE-2.0

--- a/src/lib/testrunner.js
+++ b/src/lib/testrunner.js
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019 Adobe Inc. All rights reserved.
+ * Copyright 2019 Adobe. All rights reserved.
  * This file is licensed to you under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License. You may obtain a copy
  * of the License at http://www.apache.org/licenses/LICENSE-2.0

--- a/src/lib/util.js
+++ b/src/lib/util.js
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019 Adobe Inc. All rights reserved.
+ * Copyright 2019 Adobe. All rights reserved.
  * This file is licensed to you under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License. You may obtain a copy
  * of the License at http://www.apache.org/licenses/LICENSE-2.0

--- a/src/lib/workerrunner.js
+++ b/src/lib/workerrunner.js
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019 Adobe Inc. All rights reserved.
+ * Copyright 2019 Adobe. All rights reserved.
  * This file is licensed to you under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License. You may obtain a copy
  * of the License at http://www.apache.org/licenses/LICENSE-2.0


### PR DESCRIPTION
Pull in https://github.com/adobe/eslint-config-asset-compute/releases/tag/v1.3.0

- copyright/license header with nicer * prefix formatting
- enforce semicolons