### PR TITLE
fix oclif source links to right version tags named `v...`

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,7 +46,7 @@ OPTIONS
   --version      Show version
 ```
 
-_See code: [src/commands/asset-compute/devtool.js](src/commands/asset-compute/devtool.js)_
+_See code: [src/commands/asset-compute/devtool.js](https://github.com/adobe/aio-cli-plugin-asset-compute/blob/v1.0.1/src/commands/asset-compute/devtool.js)_
 
 ## `@adobe/aio-cli-plugin-asset-compute asset-compute:run-worker FILE RENDITION`
 
@@ -73,7 +73,7 @@ OPTIONS
   --version                  Show version
 ```
 
-_See code: [src/commands/asset-compute/run-worker.js](src/commands/asset-compute/run-worker.js)_
+_See code: [src/commands/asset-compute/run-worker.js](https://github.com/adobe/aio-cli-plugin-asset-compute/blob/v1.0.1/src/commands/asset-compute/run-worker.js)_
 
 ## `@adobe/aio-cli-plugin-asset-compute asset-compute:test-worker [TESTCASE]`
 
@@ -96,7 +96,7 @@ ALIASES
   $ @adobe/aio-cli-plugin-asset-compute asset-compute:tw
 ```
 
-_See code: [src/commands/asset-compute/test-worker.js](src/commands/asset-compute/test-worker.js)_
+_See code: [src/commands/asset-compute/test-worker.js](https://github.com/adobe/aio-cli-plugin-asset-compute/blob/v1.0.1/src/commands/asset-compute/test-worker.js)_
 <!-- commandsstop -->
 
 ## Contributing

--- a/package.json
+++ b/package.json
@@ -53,8 +53,7 @@
     "bin": "",
     "devPlugins": [
       "@oclif/plugin-help"
-    ],
-    "repositoryPrefix": "<%- repo %>/blob/<%- version %>/<%- commandPath %>"
+    ]
   },
   "scripts": {
     "postpack": "rm -f oclif.manifest.json",


### PR DESCRIPTION
Following https://github.com/adobe/aio-cli-plugin-asset-compute/pull/7#issuecomment-631798987

The default `oclif-dev readme` behavior does the right thing with a `v1.0.1` tag name that we now have: https://github.com/adobe/aio-cli-plugin-asset-compute/tree/v1.0.1