### PR TITLE
NUI-556 Replace various temporary folders

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -3288,6 +3288,11 @@
         "unset-value": "^1.0.0"
       }
     },
+    "cachedir": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/cachedir/-/cachedir-2.3.0.tgz",
+      "integrity": "sha512-A+Fezp4zxnit6FanDmv9EqXNAi3vt9DWp51/71UEhXukb7QUuvtv9344h91dyAxuTLoSYJFU299qzR3tzwPAhw=="
+    },
     "caching-transform": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/caching-transform/-/caching-transform-4.0.0.tgz",

--- a/package.json
+++ b/package.json
@@ -11,6 +11,7 @@
     "@oclif/config": "^1.14.0",
     "@oclif/plugin-help": "^2.2.3",
     "amazon-s3-uri": "0.0.3",
+    "cachedir": "^2.3.0",
     "fast-csv": "^4.1.1",
     "get-port": "^5.1.1",
     "glob": "^7.1.6",

--- a/src/base-command.js
+++ b/src/base-command.js
@@ -117,6 +117,18 @@ class BaseCommand extends Command {
         return this.pjson.version;
     }
 
+    get buildDir() {
+        if (!this._buildDir) {
+            // TODO: use @adobe/aio-lib-core-config to read config once it's smaller
+            this._buildDir = process.env.AIO_BUILD_DIR || "build";
+        }
+        return this._buildDir;
+    }
+
+    getBuildDir(...subdirs) {
+        return path.resolve(this.buildDir, ...subdirs);
+    }
+
     onProcessExit(handler) {
         const SIGNALS = {
             SIGINT:  2, // ctrl+c

--- a/src/base-command.js
+++ b/src/base-command.js
@@ -119,14 +119,13 @@ class BaseCommand extends Command {
 
     get buildDir() {
         if (!this._buildDir) {
-            // TODO: use @adobe/aio-lib-core-config to read config once it's smaller
             this._buildDir = process.env.AIO_BUILD_DIR || "build";
         }
         return this._buildDir;
     }
 
     getBuildDir(...subdirs) {
-        return path.resolve(this.buildDir, ...subdirs);
+        return path.join(this.buildDir, ...subdirs);
     }
 
     onProcessExit(handler) {

--- a/src/commands/asset-compute/run-worker.js
+++ b/src/commands/asset-compute/run-worker.js
@@ -134,7 +134,10 @@ class RunWorkerCommand extends BaseCommand {
 
         params.requestId = `run-worker in ${path.basename(process.cwd())}`;
 
-        const dirs = util.prepareInOutDir();
+        // build/
+        //   run-worker/
+        //     <action>/
+        const dirs = util.prepareInOutDir(this.getBuildDir("run-worker", actionName));
 
         // copy input file
         const inFile = path.resolve(dirs.in, params.source);
@@ -160,7 +163,7 @@ class RunWorkerCommand extends BaseCommand {
 
                     const filename = rendition.name ? path.basename(rendition.name) : `rendition${idx}`;
 
-                    // copy rendition out of .nui/out if present
+                    // copy rendition if present
                     const outFile = path.resolve(dirs.out, filename);
                     const targetFile = path.resolve(targetDir, filename);
                     if (fse.existsSync(outFile)) {

--- a/src/commands/asset-compute/test-worker.js
+++ b/src/commands/asset-compute/test-worker.js
@@ -74,7 +74,15 @@ class TestWorkerCommand extends BaseCommand {
         this.testRunner = new WorkerTestRunner(dir, action, {
             startTime: startTime,
             testCasePattern: argv.args.testCase,
-            updateRenditions: argv.flags.updateRenditions
+            updateRenditions: argv.flags.updateRenditions,
+            // build/
+            //   test-worker/
+            //     <action>/
+            tempDirectory: this.getBuildDir("test-worker", actionName),
+            // build/
+            //   test-results/
+            //     test-<action>/
+            testResultDirectory: this.getBuildDir("test-results", `test-${actionName}`)
         });
 
         await this.testRunner.run();

--- a/src/lib/cloudfiles.js
+++ b/src/lib/cloudfiles.js
@@ -31,7 +31,8 @@ async function getCloudFile(file) {
     }
 }
 
-getCloudFile.CACHE_DIR = path.join(homedir, ".nui", "cache");
+// TODO: global cache dir, use npm global-cache-dir or the like
+getCloudFile.GLOBAL_CACHE_DIR = path.join(homedir, ".nui", "cache");
 
 // Handles retrieving files residing in S3
 function loadCloudFile(sourceFile) {
@@ -46,7 +47,7 @@ function loadCloudFile(sourceFile) {
             const s3Url = AmazonS3URI(fse.readFileSync(sourceFile, "utf8"));
 
             // example: ~/.nui/cache/s3.amazonaws.com/bucket/path
-            const cachePath = path.join(getCloudFile.CACHE_DIR, s3Url.uri.host, s3Url.uri.pathname);
+            const cachePath = path.join(getCloudFile.GLOBAL_CACHE_DIR, s3Url.uri.host, s3Url.uri.pathname);
             if (fse.existsSync(cachePath)) { // if file is cached, do not download from s3
                 util.log(`File cached under ${cachePath}`);
                 resolve(cachePath);

--- a/src/lib/cloudfiles.js
+++ b/src/lib/cloudfiles.js
@@ -17,10 +17,10 @@ module.exports = getCloudFile;
 const util = require('./util');
 const path = require('path');
 const fse = require('fs-extra');
-const homedir = require('os').homedir();
 const AmazonS3URI  = require('amazon-s3-uri');
 const request = require('request');
 const aws4  = require('aws4');
+const cachedir = require('cachedir');
 
 async function getCloudFile(file) {
     // If is .link file we assume the contents are the name of a cloud (S3) url
@@ -31,8 +31,7 @@ async function getCloudFile(file) {
     }
 }
 
-// TODO: global cache dir, use npm global-cache-dir or the like
-getCloudFile.GLOBAL_CACHE_DIR = path.join(homedir, ".nui", "cache");
+getCloudFile.GLOBAL_CACHE_DIR = cachedir("adobe-asset-compute");
 
 // Handles retrieving files residing in S3
 function loadCloudFile(sourceFile) {
@@ -40,20 +39,21 @@ function loadCloudFile(sourceFile) {
     	// contents of the file should be an S3 url
         // We first see if it is already cached and if so just use that
         // Otherwise we attempt to retrieve it and put it in the cache
-        if (!process.env.AWS_ACCESS_KEY_ID || !process.env.AWS_SECRET_ACCESS_KEY) {
-            reject(new Error('no s3 credentials found'));
+        const url = fse.readFileSync(sourceFile, "utf8");
+        const s3Url = AmazonS3URI(url);
+
+        // example: ~/Library/Caches/adobe-asset-compute/s3.amazonaws.com/bucket/path
+        const cachePath = path.join(getCloudFile.GLOBAL_CACHE_DIR, s3Url.uri.host, s3Url.uri.pathname);
+        if (fse.existsSync(cachePath)) { // if file is cached, do not download from s3
+            util.logToFile(`Cloud file ${url} already cached under ${cachePath}`);
+            resolve(cachePath);
 
         } else {
-            const s3Url = AmazonS3URI(fse.readFileSync(sourceFile, "utf8"));
-
-            // example: ~/.nui/cache/s3.amazonaws.com/bucket/path
-            const cachePath = path.join(getCloudFile.GLOBAL_CACHE_DIR, s3Url.uri.host, s3Url.uri.pathname);
-            if (fse.existsSync(cachePath)) { // if file is cached, do not download from s3
-                util.log(`File cached under ${cachePath}`);
-                resolve(cachePath);
+            util.logToFile(`File not cached under ${cachePath}`);
+            if (!process.env.AWS_ACCESS_KEY_ID || !process.env.AWS_SECRET_ACCESS_KEY) {
+                reject(new Error('no s3 credentials found'));
 
             } else {
-                util.log(`File not cached under ${cachePath}`);
                 const opts = {
                     service: 's3',
                     path: `/${s3Url.bucket}/${s3Url.key}`,

--- a/src/lib/util.js
+++ b/src/lib/util.js
@@ -41,20 +41,22 @@ module.exports = {
 
     logError: logError,
 
-    dotNui: function (...p) {
-        return path.resolve('.nui', ...p);
-    },
-
     // create temporary hidden folder for in & out dirs to mount
-    prepareInOutDir: function () {
+    prepareInOutDir: function (buildDir) {
+        // TODO: remove once all has been moved
+        // TODO: remove once all has been moved
+        // TODO: remove once all has been moved
+        // TODO: remove once all has been moved
+        buildDir = buildDir || '.nui';
+
         const uniqueName = (process.env.BUILD_TAG || new Date().toISOString()).replace(/[^a-zA-Z0-9_]/g, '_');
         const dirs = {
-            dotNui: this.dotNui(),
-            work: this.dotNui(uniqueName),
-            in: this.dotNui(uniqueName, 'in'),
-            out: this.dotNui(uniqueName, 'out'),
-            failed: this.dotNui(uniqueName, 'failed'),
-            mock_crt: this.dotNui(uniqueName, 'mock-crt')
+            build: buildDir,
+            work: path.resolve(buildDir, uniqueName),
+            in: path.resolve(buildDir, uniqueName, 'in'),
+            out: path.resolve(buildDir, uniqueName, 'out'),
+            failed: path.resolve(buildDir, uniqueName, 'failed'),
+            mock_crt: path.resolve(buildDir, uniqueName, 'mock-crt')
         };
         fse.ensureDirSync(dirs.in);
         // ensure readable by mounted docker container by giving everyone read
@@ -72,7 +74,7 @@ module.exports = {
         return dirs;
     },
 
-    // remove temporary .nui/in + out dirs and failed if empty
+    // remove temporary in + out dirs and failed if empty
     cleanupInOutDir: function (dirs) {
         if (!dirs) {
             return;
@@ -87,9 +89,9 @@ module.exports = {
             fse.removeSync(dirs.work);
         }
 
-        // remove .nui if empty and unused otherwise
-        if (dirExistsAndEmpty(dirs.dotNui)) {
-            fse.removeSync(dirs.dotNui);
+        // remove build dir if empty and unused otherwise
+        if (dirExistsAndEmpty(dirs.build)) {
+            fse.removeSync(dirs.build);
         }
     },
 

--- a/src/lib/util.js
+++ b/src/lib/util.js
@@ -43,19 +43,13 @@ module.exports = {
 
     // create temporary hidden folder for in & out dirs to mount
     prepareInOutDir: function (buildDir) {
-        // TODO: remove once all has been moved
-        // TODO: remove once all has been moved
-        // TODO: remove once all has been moved
-        // TODO: remove once all has been moved
-        buildDir = buildDir || '.nui';
-
         const uniqueName = (process.env.BUILD_TAG || new Date().toISOString()).replace(/[^a-zA-Z0-9_]/g, '_');
         const dirs = {
-            build: buildDir,
-            work: path.resolve(buildDir, uniqueName),
-            in: path.resolve(buildDir, uniqueName, 'in'),
-            out: path.resolve(buildDir, uniqueName, 'out'),
-            failed: path.resolve(buildDir, uniqueName, 'failed'),
+            build:    buildDir,
+            work:     path.resolve(buildDir, uniqueName),
+            in:       path.resolve(buildDir, uniqueName, 'in'),
+            out:      path.resolve(buildDir, uniqueName, 'out'),
+            failed:   path.resolve(buildDir, uniqueName, 'failed'),
             mock_crt: path.resolve(buildDir, uniqueName, 'mock-crt')
         };
         fse.ensureDirSync(dirs.in);

--- a/test/commands/run-worker.test.js
+++ b/test/commands/run-worker.test.js
@@ -12,7 +12,7 @@
 
 'use strict';
 
-const { testCommand, assertExitCode } = require("./testutil");
+const { testCommand, assertExitCode, assertMissingOrEmptyDirectory } = require("./testutil");
 const assert = require("assert");
 const fs = require("fs");
 const path = require("path");
@@ -34,7 +34,9 @@ describe("run-worker command", function() {
                 // check files are identical (the worker just copies source -> rendition)
                 assert(fs.readFileSync("tests/simple/file.jpg").equals(fs.readFileSync("rendition.jpg")));
 
+                // legacy build folder, ensure it does not come back
                 assert(!fs.existsSync(".nui"));
+                assertMissingOrEmptyDirectory("build", "run-worker");
             });
 
         testCommand("test-projects/multiple-workers", "asset-compute:run-worker", ["-a", "workerA", "actions/workerA/tests/testA/file.jpg", "rendition.jpg"])
@@ -50,6 +52,7 @@ describe("run-worker command", function() {
                 assert(fs.readFileSync("actions/workerA/tests/testA/file.jpg").equals(fs.readFileSync("rendition.jpg")));
 
                 assert(!fs.existsSync(".nui"));
+                assertMissingOrEmptyDirectory("build", "run-worker");
             });
 
         testCommand("test-projects/multiple-workers", "asset-compute:run-worker", ["-a", "workerB", "actions/workerB/tests/testB/file.jpg", "rendition.jpg"])
@@ -65,6 +68,7 @@ describe("run-worker command", function() {
                 assert(fs.readFileSync("actions/workerB/tests/testB/file.jpg").equals(fs.readFileSync("rendition.jpg")));
 
                 assert(!fs.existsSync(".nui"));
+                assertMissingOrEmptyDirectory("build", "run-worker");
             });
 
         testCommand("test-projects/echo-params", "asset-compute:run-worker", ["package.json", "rendition.json", "-p", "key", "value"])
@@ -79,6 +83,7 @@ describe("run-worker command", function() {
                 assert.equal(result.key, "value");
 
                 assert(!fs.existsSync(".nui"));
+                assertMissingOrEmptyDirectory("build", "run-worker");
             });
 
         testCommand("test-projects/echo-params", "asset-compute:run-worker", ["package.json", "rendition.json", "-P", "params.json"])
@@ -93,6 +98,7 @@ describe("run-worker command", function() {
                 assert.equal(result.greeting, "hello world");
 
                 assert(!fs.existsSync(".nui"));
+                assertMissingOrEmptyDirectory("build", "run-worker");
             });
 
         testCommand("test-projects/echo-params", "asset-compute:run-worker", ["package.json", "renditionDir", "-d", '{ "renditions": [{ "key": "value" }] }'])
@@ -108,6 +114,7 @@ describe("run-worker command", function() {
                 assert.equal(result.key, "value");
 
                 assert(!fs.existsSync(".nui"));
+                assertMissingOrEmptyDirectory("build", "run-worker");
             });
 
         const renditionJson = {
@@ -137,6 +144,7 @@ describe("run-worker command", function() {
                 assert.equal(result2.key, "2");
 
                 assert(!fs.existsSync(".nui"));
+                assertMissingOrEmptyDirectory("build", "run-worker");
             });
     });
 
@@ -149,6 +157,7 @@ describe("run-worker command", function() {
 
                 assert(!fs.existsSync("rendition.jpg"));
                 assert(!fs.existsSync(".nui"));
+                assertMissingOrEmptyDirectory("build", "run-worker");
             });
     });
 });

--- a/test/commands/test-worker.test.js
+++ b/test/commands/test-worker.test.js
@@ -126,6 +126,9 @@ describe("test-worker command", function() {
                 assert(ctx.stdout.includes("- Failures       : 0"));
                 assert(ctx.stdout.includes("- Errors         : 0"));
 
+                assert(fs.existsSync(path.join(getCloudFile.GLOBAL_CACHE_DIR, "s3.amazonaws.com", "asset-compute-cli-test-bucket", "rendition")));
+                assert(fs.existsSync(path.join(getCloudFile.GLOBAL_CACHE_DIR, "s3.amazonaws.com", "asset-compute-cli-test-bucket", "source")));
+
                 assert(!fs.existsSync(".nui"));
                 assert(!fs.existsSync(path.join("actions", "worker", "build")));
                 assertMissingOrEmptyDirectory("build", "test-worker");

--- a/test/commands/test-worker.test.js
+++ b/test/commands/test-worker.test.js
@@ -14,13 +14,19 @@
 
 const getCloudFile = require("../../src/lib/cloudfiles");
 
-const { testCommand, assertExitCode, assertOccurrences } = require("./testutil");
+const { testCommand, assertExitCode, assertOccurrences, assertMissingOrEmptyDirectory } = require("./testutil");
 const assert = require("assert");
 const path = require("path");
 const fs = require("fs");
 const glob = require("glob");
 const rimraf = require("rimraf");
 const nock = require("nock");
+
+function assertTestResults(action) {
+    assert(fs.existsSync(path.join("build", "test-results", `test-${action}`, "test.log")));
+    assert(fs.existsSync(path.join("build", "test-results", `test-${action}`, "test-results.xml")));
+    assert(fs.existsSync(path.join("build", "test-results", `test-${action}`, "test-timing-results.csv")));
+}
 
 // TODO test ctrl+c (might need a child process)
 // TODO test argument -u
@@ -41,7 +47,15 @@ describe("test-worker command", function() {
                 assertOccurrences(ctx.stdout, "- Tests run      : 1", 2);
                 assertOccurrences(ctx.stdout, "- Failures       : 0", 2);
                 assertOccurrences(ctx.stdout, "- Errors         : 0", 2);
+
+                // legacy build folder, ensure it does not come back
                 assert(!fs.existsSync(".nui"));
+                // build directory must be in root
+                assert(!fs.existsSync(path.join("actions", "workerA", "build")));
+                assert(!fs.existsSync(path.join("actions", "workerB", "build")));
+                assertMissingOrEmptyDirectory("build", "test-worker");
+                assertTestResults("workerA");
+                assertTestResults("workerB");
             });
 
         testCommand("test-projects/multiple-workers", "asset-compute:test-worker", ["-a", "workerA"])
@@ -55,7 +69,11 @@ describe("test-worker command", function() {
                 assertOccurrences(ctx.stdout, "- Tests run      : 1", 1);
                 assertOccurrences(ctx.stdout, "- Failures       : 0", 1);
                 assertOccurrences(ctx.stdout, "- Errors         : 0", 1);
+
                 assert(!fs.existsSync(".nui"));
+                assert(!fs.existsSync(path.join("actions", "workerA", "build")));
+                assertMissingOrEmptyDirectory("build", "test-worker");
+                assertTestResults("workerA");
             });
 
         testCommand("test-projects/single-worker", "asset-compute:test-worker")
@@ -67,7 +85,11 @@ describe("test-worker command", function() {
                 assert(ctx.stdout.includes("- Tests run      : 1"));
                 assert(ctx.stdout.includes("- Failures       : 0"));
                 assert(ctx.stdout.includes("- Errors         : 0"));
+
                 assert(!fs.existsSync(".nui"));
+                assert(!fs.existsSync(path.join("actions", "worker", "build")));
+                assertMissingOrEmptyDirectory("build", "test-worker");
+                assertTestResults("worker");
             });
 
         testCommand("test-projects/mockserver", "asset-compute:test-worker")
@@ -79,7 +101,11 @@ describe("test-worker command", function() {
                 assert(ctx.stdout.includes("- Tests run      : 1"));
                 assert(ctx.stdout.includes("- Failures       : 0"));
                 assert(ctx.stdout.includes("- Errors         : 0"));
+
                 assert(!fs.existsSync(".nui"));
+                assert(!fs.existsSync(path.join("actions", "worker", "build")));
+                assertMissingOrEmptyDirectory("build", "test-worker");
+                assertTestResults("worker");
             });
 
         testCommand("test-projects/cloudfiles", "asset-compute:test-worker")
@@ -87,7 +113,7 @@ describe("test-worker command", function() {
                 process.env.AWS_ACCESS_KEY_ID = "key";
                 process.env.AWS_SECRET_ACCESS_KEY = "secret";
                 // ensure the cloudfiles cache is deleted
-                rimraf.sync(path.join(getCloudFile.CACHE_DIR, "s3.amazonaws.com", "asset-compute-cli-test-bucket"));
+                rimraf.sync(path.join(getCloudFile.GLOBAL_CACHE_DIR, "s3.amazonaws.com", "asset-compute-cli-test-bucket"));
                 nock("https://s3.amazonaws.com").get("/asset-compute-cli-test-bucket/source").reply(200, "correct file");
                 nock("https://s3.amazonaws.com").get("/asset-compute-cli-test-bucket/rendition").reply(200, "correct file");
             })
@@ -99,7 +125,11 @@ describe("test-worker command", function() {
                 assert(ctx.stdout.includes("- Tests run      : 1"));
                 assert(ctx.stdout.includes("- Failures       : 0"));
                 assert(ctx.stdout.includes("- Errors         : 0"));
+
                 assert(!fs.existsSync(".nui"));
+                assert(!fs.existsSync(path.join("actions", "worker", "build")));
+                assertMissingOrEmptyDirectory("build", "test-worker");
+                assertTestResults("worker");
             });
     });
 
@@ -109,34 +139,42 @@ describe("test-worker command", function() {
             .it("fails with exit code 1 if test fails due to a different rendition result", function(ctx) {
                 assertExitCode(1);
                 assert(ctx.stdout.includes(" - fails"));
-                assert(ctx.stdout.includes("✖  Failure: Rendition 'rendition0.jpg' not as expected. Validate exit code was: 2. Check build/test.log."));
+                assert(ctx.stdout.includes("✖  Failure: Rendition 'rendition0.jpg' not as expected. Validate exit code was: 2. Check build/test-results/test-worker/test.log."));
                 assert(ctx.stdout.includes("error: There were test failures."));
                 assert(ctx.stdout.includes("- Tests run      : 1"));
                 assert(ctx.stdout.includes("- Failures       : 1"));
                 assert(ctx.stdout.includes("- Errors         : 0"));
-                assert(glob.sync(".nui/*/failed/fails/rendition0.jpg").length, 1);
+                assert(glob.sync("build/test-worker/**/failed/fails/rendition0.jpg").length, 1);
+                assertMissingOrEmptyDirectory("build", "test-worker");
+                assertTestResults("worker");
             });
 
         testCommand("test-projects/test-failure-missing-rendition", "asset-compute:test-worker")
             .it("fails with exit code 1 if test fails due to a missing rendition", function(ctx) {
                 assertExitCode(1);
                 assert(ctx.stdout.includes(" - fails"));
-                assert(ctx.stdout.includes("✖  Failure: No rendition generated. Check build/test.log."));
+                assert(ctx.stdout.includes("✖  Failure: No rendition generated. Check build/test-results/test-worker/test.log."));
                 assert(ctx.stdout.includes("error: There were test failures."));
                 assert(ctx.stdout.includes("- Tests run      : 1"));
                 assert(ctx.stdout.includes("- Failures       : 1"));
                 assert(ctx.stdout.includes("- Errors         : 0"));
+                assertMissingOrEmptyDirectory("build", "test-worker");
+                assertTestResults("worker");
             });
 
         testCommand("test-projects/invocation-error", "asset-compute:test-worker")
             .it("fails with exit code 2 if the worker invocation errors", function() {
                 assertExitCode(2);
+                assertMissingOrEmptyDirectory("build", "test-worker");
+                assertTestResults("worker");
             });
 
         testCommand("test-projects/build-error", "asset-compute:test-worker")
             .it("fails with exit code 3 if the worker does not build (has no manifest)", function(ctx) {
                 assertExitCode(3);
                 assert(ctx.stderr.match(/error.*manifest.yml/i));
+                assertMissingOrEmptyDirectory("build", "test-worker");
+                assertMissingOrEmptyDirectory("build", "test-results");
             });
 
     });

--- a/test/commands/testutil.js
+++ b/test/commands/testutil.js
@@ -58,7 +58,6 @@ function testCommand(dir, command, args=[]) {
             rimraf.sync("dist");
             // remove temp directories
             rimraf.sync("build");
-            rimraf.sync(".nui");
 
             // install dependencies for the project
             execSync("npm install");

--- a/test/commands/testutil.js
+++ b/test/commands/testutil.js
@@ -23,6 +23,7 @@ const { execSync } = require("child_process");
 const rimraf = require("rimraf");
 const assert = require("assert");
 const Docker = require("dockerode");
+const fs = require("fs");
 
 const baseDir = process.cwd();
 
@@ -128,8 +129,15 @@ function assertOccurrences(str, substr, expectedCount) {
     assert.equal(str.split(substr).length - 1, expectedCount);
 }
 
+function assertMissingOrEmptyDirectory(...pathElements) {
+    const fullPath = path.join(...pathElements);
+    return !fs.existsSync(fullPath) || fs.readdirSync(fullPath).length === 0;
+}
+
+
 module.exports = {
     testCommand,
     assertExitCode,
-    assertOccurrences
+    assertOccurrences,
+    assertMissingOrEmptyDirectory
 };


### PR DESCRIPTION
For [NUI-556](https://jira.corp.adobe.com/browse/NUI-556).

Move all temporary files in `build` directory of project root.
- Can be overwritten using `AIO_BUILD_DIR` environment variable.
- Inside that directory shadow the action names as the project can contain multiple actions.
- Ensure no conflicts for future additions to the `build` directory by other tools by using `build/test-worker` and `build/run-worker` unique subdirectories.
- Test results are put into `build/test-results/test-<action>`. This supports [circleci multiple test results](https://circleci.com/docs/2.0/configuration-reference/#store_test_results) if it is configured with `build/test-results`.

Change global cache dir from `~/.nui` to `adobe-asset-compute` inside OS cache dir provided by [cachedir](https://www.npmjs.com/package/cachedir) module. For example, `~/Library/Caches/adobe-asset-compute` on Mac.

Old structure:

```
manifest.yml
package.json

actions/
  myworker/
    build/
      test.log
      test-results.xml
      test-timing-results.csv

.nui/
  ...
```

New structure:

```
manifest.yml
package.json

actions/
  myworker/  ............. untouched, all in root under build/

build/
  run-worker/
  test-worker/
    <action>/  ............. previously .nui/
      ...
  test-results/
    test-<action>/  ............. previously build/
      test.log
      test-results.xml
      test-timing-results.csv
```

Steps:
- [x] change temp directories for `run-worker: `.nui` -> `build`
- [x] change temp directories `run-worker`: `.nui` and `build` -> `build`
- [x] change global cache directory for s3 files: `~/.nui` -> use `cachedir` module
