### PR TITLE
NUI-561 hybrid cli: standalone and aio plugin

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,34 +10,94 @@ Asset Compute Plugin for Adobe I/O Command Line Interface
 
 <!-- tocstop -->
 
-## Usage
+## Installation and Usage
 
-This plugin has [aio-cli](https://github.com/adobe/aio-cli) as a prerequisite. Once `aio-cli` has been installed, the plugin can be installed and used as follows:
+This can be installed & used in three ways:
 
-```sh-session
-$ aio plugins:install @adobe/aio-cli-plugin-asset-compute
-$ aio asset-compute:test-worker --help
-Usage information of the test-worker command
-$ aio asset-compute:test-worker -u
-Update rendition output
-$ aio asset-compute:tw
-Alias for the test-worker command
-$ aio asset-compute:devtool
-Runs the Asset Compute Developer Tool UI
+1. [aio plugin](#install-as-aio-plugin)
+2. [local devDependency](#install-as-local-devdependency)
+3. [global standalone cli](#install-as-global-standalone-cli)
+
+### Install as aio plugin
+
+This requires [aio-cli](https://github.com/adobe/aio-cli).
+
+```
+aio plugins:install @adobe/aio-cli-plugin-asset-compute
+```
+
+It provides the `asset-compute` command topic. You can run e.g. the test command using:
+
+```
+aio asset-compute test-worker
+```
+
+Help and available commands can be seen with:
+
+```
+aio asset-compute
+```
+
+### Install as local devDependency
+
+Install into your `devDependencies`:
+
+```
+npm install --save-dev @adobe/aio-cli-plugin-asset-compute
+```
+
+Then use in `npm` scripts in your `package.json`, for example for tests:
+
+```json
+   "scripts": {
+       "test": "adobe-asset-compute test-worker"
+   }
+```
+
+Use `npx` if you want to manually run it. Inside your project run for example:
+
+```
+npx adobe-asset-compute run-worker
+```
+
+Help and available commands can be seen with:
+
+```
+npx adobe-asset-compute
+```
+
+### Install as global standalone cli
+
+Install globally using:
+
+```
+npm install -g @adobe/aio-cli-plugin-asset-compute
+```
+
+This will add the `adobe-asset-compute` cli to your system. Run using:
+
+```
+adobe-asset-compute test-worker
+```
+
+Help and available commands can be seen with:
+
+```
+adobe-asset-compute
 ```
 
 ## Commands
 <!-- commands -->
-* [`@adobe/aio-cli-plugin-asset-compute asset-compute:run-worker FILE RENDITION`](#adobeaio-cli-plugin-asset-compute-asset-computerun-worker-file-rendition)
-* [`@adobe/aio-cli-plugin-asset-compute asset-compute:test-worker [TESTCASE]`](#adobeaio-cli-plugin-asset-compute-asset-computetest-worker-testcase)
+* [`adobe-asset-compute run-worker FILE RENDITION`](#adobe-asset-compute-run-worker-file-rendition)
+* [`adobe-asset-compute test-worker [TESTCASE]`](#adobe-asset-compute-test-worker-testcase)
 
-## `@adobe/aio-cli-plugin-asset-compute asset-compute:run-worker FILE RENDITION`
+## `adobe-asset-compute run-worker FILE RENDITION`
 
 Run worker from local project using Docker
 
 ```
 USAGE
-  $ @adobe/aio-cli-plugin-asset-compute asset-compute:run-worker FILE RENDITION
+  $ adobe-asset-compute run-worker FILE RENDITION
 
 ARGUMENTS
   FILE       Path to input file for worker
@@ -55,15 +115,13 @@ OPTIONS
   --version                  Show version
 ```
 
-_See code: [src/commands/asset-compute/run-worker.js](https://github.com/adobe/aio-cli-plugin-asset-compute/blob/v1.0.3/src/commands/asset-compute/run-worker.js)_
-
-## `@adobe/aio-cli-plugin-asset-compute asset-compute:test-worker [TESTCASE]`
+## `adobe-asset-compute test-worker [TESTCASE]`
 
 Run tests from local project
 
 ```
 USAGE
-  $ @adobe/aio-cli-plugin-asset-compute asset-compute:test-worker [TESTCASE]
+  $ adobe-asset-compute test-worker [TESTCASE]
 
 ARGUMENTS
   TESTCASE  Test case(s) to run. Supports glob patterns. If not set, runs all tests.
@@ -75,10 +133,8 @@ OPTIONS
   --version               Show version
 
 ALIASES
-  $ @adobe/aio-cli-plugin-asset-compute asset-compute:tw
+  $ adobe-asset-compute tw
 ```
-
-_See code: [src/commands/asset-compute/test-worker.js](https://github.com/adobe/aio-cli-plugin-asset-compute/blob/v1.0.3/src/commands/asset-compute/test-worker.js)_
 <!-- commandsstop -->
 
 ## Contributing

--- a/README.md
+++ b/README.md
@@ -144,3 +144,4 @@ Contributions are welcomed! Read the [Contributing Guide](./.github/CONTRIBUTING
 ## Licensing
 
 This project is licensed under the Apache V2 License. See [LICENSE](LICENSE) for more information.
+

--- a/README.md
+++ b/README.md
@@ -144,4 +144,3 @@ Contributions are welcomed! Read the [Contributing Guide](./.github/CONTRIBUTING
 ## Licensing
 
 This project is licensed under the Apache V2 License. See [LICENSE](LICENSE) for more information.
-

--- a/bin/run
+++ b/bin/run
@@ -1,4 +1,17 @@
 #!/usr/bin/env node
+/*
+ * Copyright 2020 Adobe. All rights reserved.
+ * This file is licensed to you under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License. You may obtain a copy
+ * of the License at http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under
+ * the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
+ * OF ANY KIND, either express or implied. See the License for the specific language
+ * governing permissions and limitations under the License.
+ */
+
+'use strict';
 
 require('@oclif/command').run()
-.catch(require('@oclif/errors/handle'))
+    .catch(require('@oclif/errors/handle'));

--- a/bin/run.cmd
+++ b/bin/run.cmd
@@ -1,3 +1,13 @@
 @echo off
 
+REM Copyright 2020 Adobe. All rights reserved.
+REM This file is licensed to you under the Apache License, Version 2.0 (the "License");
+REM you may not use this file except in compliance with the License. You may obtain a copy
+REM of the License at http://www.apache.org/licenses/LICENSE-2.0
+REM
+REM Unless required by applicable law or agreed to in writing, software distributed under
+REM the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
+REM OF ANY KIND, either express or implied. See the License for the specific language
+REM governing permissions and limitations under the License.
+
 node "%~dp0\run" %*

--- a/package.json
+++ b/package.json
@@ -37,7 +37,8 @@
     "mocha": "^7.1.2",
     "nock": "^12.0.3",
     "nyc": "^15.0.1",
-    "semantic-release": "17.0.7"
+    "semantic-release": "17.0.7",
+    "stdout-stderr": "^0.1.13"
   },
   "engines": {
     "node": ">=10.0.0"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@adobe/aio-cli-plugin-asset-compute",
-  "description": "Asset Compute Plugin for Adobe I/O Command Line Interface",
+  "description": "Tool to develop and test Adobe Asset Compute workers",
   "version": "1.0.3",
   "author": "Adobe Inc.",
   "license": "Apache-2.0",
@@ -57,16 +57,23 @@
     "adobe",
     "openwhisk"
   ],
+  "main": "bin/run",
+  "bin": {
+    "adobe-asset-compute": "bin/run"
+  },
   "oclif": {
     "commands": "./src/commands",
-    "bin": "",
+    "bin": "adobe-asset-compute",
     "devPlugins": [
       "@oclif/plugin-help"
-    ]
+    ],
+    "hooks": {
+      "init": "./src/hooks/init.js"
+    }
   },
   "scripts": {
     "prepare": "oclif-dev manifest && oclif-dev readme",
-    "version": "oclif-dev manifest && oclif-dev readme && git add README.md",
+    "version": "npm run prepare && git add README.md",
     "postpack": "rm -f oclif.manifest.json",
     "test": "nyc mocha test/*/*.test.js",
     "posttest": "eslint .",

--- a/src/commands/asset-compute/index.js
+++ b/src/commands/asset-compute/index.js
@@ -1,6 +1,5 @@
-#!/usr/bin/env node
 /*
- * Copyright 2020 Adobe. All rights reserved.
+ * Copyright 2019 Adobe. All rights reserved.
  * This file is licensed to you under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License. You may obtain a copy
  * of the License at http://www.apache.org/licenses/LICENSE-2.0
@@ -13,8 +12,16 @@
 
 'use strict';
 
-// support -h in addition to --help everywhere
-process.argv = process.argv.map(v => v === "-h" ? "--help" : v);
+const HHelp = require('@oclif/plugin-help').default;
+const BaseCommand = require('../../base-command');
 
-require('@oclif/command').run()
-    .catch(require('@oclif/errors/handle'));
+class IndexCommand extends BaseCommand {
+    async run() {
+        const help = new HHelp(this.config);
+        help.showHelp(['asset-compute', '--help']);
+    }
+}
+
+IndexCommand.description = 'Develop and test Adobe Asset Compute workers';
+
+module.exports = IndexCommand;

--- a/src/hooks/init.js
+++ b/src/hooks/init.js
@@ -1,0 +1,39 @@
+/*
+ * Copyright 2019 Adobe. All rights reserved.
+ * This file is licensed to you under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License. You may obtain a copy
+ * of the License at http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under
+ * the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
+ * OF ANY KIND, either express or implied. See the License for the specific language
+ * governing permissions and limitations under the License.
+ */
+
+'use strict';
+
+// oclif init hook for running this oclif plugin in hybrid mode
+// both as standalone cli and as plugin for another oclif cli
+
+// <topic>:<command> => <command>
+function removeTopic(id) {
+    // will keep the original string if no ":" found
+    return id.substring(id.indexOf(":") + 1);
+}
+
+module.exports = async function (opts) {
+    // check if we run as standalone cli or as part of another plugin
+    // by checking if the root package.json name that oclif sees is ours
+    if (opts.config.pjson.name === require("../../package.json").name) {
+        // drop the topic to move commands to the top level
+        opts.config.commands.forEach(command => {
+            if (command.id.indexOf(":") < 0) {
+                // hide any "index" command for the topic itself
+                command.hidden = true;
+            } else {
+                command.id = removeTopic(command.id);
+                command.aliases = command.aliases.map(removeTopic);
+            }
+        });
+    }
+};

--- a/test/commands/index.test.js
+++ b/test/commands/index.test.js
@@ -1,0 +1,29 @@
+/*
+ * Copyright 2020 Adobe. All rights reserved.
+ * This file is licensed to you under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License. You may obtain a copy
+ * of the License at http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under
+ * the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
+ * OF ANY KIND, either express or implied. See the License for the specific language
+ * governing permissions and limitations under the License.
+ */
+
+'use strict';
+
+const IndexCommand = require("../../src/commands/asset-compute");
+const {stdout} = require("stdout-stderr");
+const assert = require("assert");
+
+describe("index command", function() {
+
+    it("should show help for asset-compute commands", async function() {
+        stdout.start();
+        await IndexCommand.run([]);
+        stdout.stop();
+        assert(stdout.output.startsWith("Develop and test Adobe Asset Compute workers"));
+        assert(stdout.output.includes("asset-compute:run-worker   Run worker from local project using Docker"));
+        assert(stdout.output.includes("asset-compute:test-worker  Run tests from local project"));
+    });
+});

--- a/test/commands/run-worker.test.js
+++ b/test/commands/run-worker.test.js
@@ -22,7 +22,7 @@ describe("run-worker command", function() {
 
     describe("success", function() {
 
-        testCommand("test-projects/single-worker", "asset-compute:run-worker", ["test/asset-compute/worker/simple/file.jpg", "rendition.jpg"])
+        testCommand("test-projects/single-worker", "run-worker", ["test/asset-compute/worker/simple/file.jpg", "rendition.jpg"])
             .finally(() => {
                 // cleanup afterwards
                 fs.unlinkSync("rendition.jpg");
@@ -39,7 +39,7 @@ describe("run-worker command", function() {
                 assertMissingOrEmptyDirectory("build", "run-worker");
             });
 
-        testCommand("test-projects/multiple-workers", "asset-compute:run-worker", ["-a", "workerA", "test/asset-compute/workerA/testA/file.jpg", "rendition.jpg"])
+        testCommand("test-projects/multiple-workers", "run-worker", ["-a", "workerA", "test/asset-compute/workerA/testA/file.jpg", "rendition.jpg"])
             .finally(() => {
                 fs.unlinkSync("rendition.jpg");
             })
@@ -55,7 +55,7 @@ describe("run-worker command", function() {
                 assertMissingOrEmptyDirectory("build", "run-worker");
             });
 
-        testCommand("test-projects/multiple-workers", "asset-compute:run-worker", ["-a", "workerB", "test/asset-compute/workerB/testB/file.jpg", "rendition.jpg"])
+        testCommand("test-projects/multiple-workers", "run-worker", ["-a", "workerB", "test/asset-compute/workerB/testB/file.jpg", "rendition.jpg"])
             .finally(() => {
                 fs.unlinkSync("rendition.jpg");
             })
@@ -71,7 +71,7 @@ describe("run-worker command", function() {
                 assertMissingOrEmptyDirectory("build", "run-worker");
             });
 
-        testCommand("test-projects/echo-params", "asset-compute:run-worker", ["package.json", "rendition.json", "-p", "key", "value"])
+        testCommand("test-projects/echo-params", "run-worker", ["package.json", "rendition.json", "-p", "key", "value"])
             .finally(() => {
                 fs.unlinkSync("rendition.json");
             })
@@ -86,7 +86,7 @@ describe("run-worker command", function() {
                 assertMissingOrEmptyDirectory("build", "run-worker");
             });
 
-        testCommand("test-projects/echo-params", "asset-compute:run-worker", ["package.json", "rendition.json", "-P", "params.json"])
+        testCommand("test-projects/echo-params", "run-worker", ["package.json", "rendition.json", "-P", "params.json"])
             .finally(() => {
                 fs.unlinkSync("rendition.json");
             })
@@ -101,7 +101,7 @@ describe("run-worker command", function() {
                 assertMissingOrEmptyDirectory("build", "run-worker");
             });
 
-        testCommand("test-projects/echo-params", "asset-compute:run-worker", ["package.json", "renditionDir", "-d", '{ "renditions": [{ "key": "value" }] }'])
+        testCommand("test-projects/echo-params", "run-worker", ["package.json", "renditionDir", "-d", '{ "renditions": [{ "key": "value" }] }'])
             .finally(() => {
                 rimraf.sync("renditionDir");
             })
@@ -126,7 +126,7 @@ describe("run-worker command", function() {
                 key: "2"
             }]
         };
-        testCommand("test-projects/echo-params", "asset-compute:run-worker", ["package.json", "renditionDir", "-d", JSON.stringify(renditionJson)])
+        testCommand("test-projects/echo-params", "run-worker", ["package.json", "renditionDir", "-d", JSON.stringify(renditionJson)])
             .finally(() => {
                 rimraf.sync("renditionDir");
             })
@@ -150,7 +150,7 @@ describe("run-worker command", function() {
 
     describe("failure", function() {
 
-        testCommand("test-projects/multiple-workers", "asset-compute:run-worker", ["test/asset-compute/worker/simple/file.jpg", "rendition.jpg"])
+        testCommand("test-projects/multiple-workers", "run-worker", ["test/asset-compute/worker/simple/file.jpg", "rendition.jpg"])
             .it("fails with exit code 1 if run on a project with multiple workers and no -a is set", function(ctx) {
                 assertExitCode(1);
                 assert(ctx.stderr.includes("Error: Must specify worker to run using --action"));

--- a/test/commands/test-worker.test.js
+++ b/test/commands/test-worker.test.js
@@ -35,7 +35,7 @@ describe("test-worker command", function() {
 
     describe("success", function() {
 
-        testCommand("test-projects/multiple-workers", "asset-compute:test-worker")
+        testCommand("test-projects/multiple-workers", "test-worker")
             .it("runs tests for all workers", function(ctx) {
                 assertExitCode(undefined);
                 assert(ctx.stdout.includes("Actions:\n- workerA\n- workerB"));
@@ -58,7 +58,7 @@ describe("test-worker command", function() {
                 assertTestResults("workerB");
             });
 
-        testCommand("test-projects/multiple-workers", "asset-compute:test-worker", ["-a", "workerA"])
+        testCommand("test-projects/multiple-workers", "test-worker", ["-a", "workerA"])
             .it("runs tests for the selected worker if -a is set", function(ctx) {
                 assertExitCode(undefined);
                 assert(!ctx.stdout.includes("workerB"));
@@ -76,7 +76,7 @@ describe("test-worker command", function() {
                 assertTestResults("workerA");
             });
 
-        testCommand("test-projects/single-worker", "asset-compute:test-worker")
+        testCommand("test-projects/single-worker", "test-worker")
             .it("runs tests for a single worker at the root", function(ctx) {
                 assertExitCode(undefined);
                 assert(ctx.stdout.includes(" - simple"));
@@ -92,7 +92,7 @@ describe("test-worker command", function() {
                 assertTestResults("worker");
             });
 
-        testCommand("test-projects/mockserver", "asset-compute:test-worker")
+        testCommand("test-projects/mockserver", "test-worker")
             .it("runs successful tests with a mocked domain", function(ctx) {
                 assertExitCode(undefined);
                 assert(ctx.stdout.includes(" - mock"));
@@ -108,7 +108,7 @@ describe("test-worker command", function() {
                 assertTestResults("worker");
             });
 
-        testCommand("test-projects/cloudfiles", "asset-compute:test-worker")
+        testCommand("test-projects/cloudfiles", "test-worker")
             .prepare(() => {
                 process.env.AWS_ACCESS_KEY_ID = "key";
                 process.env.AWS_SECRET_ACCESS_KEY = "secret";
@@ -135,7 +135,7 @@ describe("test-worker command", function() {
                 assertTestResults("worker");
             });
 
-        testCommand("test-projects/no-tests", "asset-compute:test-worker")
+        testCommand("test-projects/no-tests", "test-worker")
             .it("succeeds with non-zero exit code if there are no tests", function() {
                 assertExitCode(undefined);
                 assertMissingOrEmptyDirectory("build", "test-worker");
@@ -146,7 +146,7 @@ describe("test-worker command", function() {
 
     describe("failure", function() {
 
-        testCommand("test-projects/test-failure-rendition", "asset-compute:test-worker")
+        testCommand("test-projects/test-failure-rendition", "test-worker")
             .it("fails with exit code 1 if test fails due to a different rendition result", function(ctx) {
                 assertExitCode(1);
                 assert(ctx.stdout.includes(" - fails"));
@@ -160,7 +160,7 @@ describe("test-worker command", function() {
                 assertTestResults("worker");
             });
 
-        testCommand("test-projects/test-failure-missing-rendition", "asset-compute:test-worker")
+        testCommand("test-projects/test-failure-missing-rendition", "test-worker")
             .it("fails with exit code 1 if test fails due to a missing rendition", function(ctx) {
                 assertExitCode(1);
                 assert(ctx.stdout.includes(" - fails"));
@@ -173,14 +173,14 @@ describe("test-worker command", function() {
                 assertTestResults("worker");
             });
 
-        testCommand("test-projects/invocation-error", "asset-compute:test-worker")
+        testCommand("test-projects/invocation-error", "test-worker")
             .it("fails with exit code 2 if the worker invocation errors", function() {
                 assertExitCode(2);
                 assertMissingOrEmptyDirectory("build", "test-worker");
                 assertTestResults("worker");
             });
 
-        testCommand("test-projects/build-error", "asset-compute:test-worker")
+        testCommand("test-projects/build-error", "test-worker")
             .it("fails with exit code 3 if the worker does not build (has no manifest)", function(ctx) {
                 assertExitCode(3);
                 assert(ctx.stderr.match(/error.*manifest.yml/i));
@@ -188,7 +188,7 @@ describe("test-worker command", function() {
                 assertMissingOrEmptyDirectory("build", "test-results");
             });
 
-        testCommand("test-projects/test-name-mismatch", "asset-compute:test-worker")
+        testCommand("test-projects/test-name-mismatch", "test-worker")
             .it("fails with exit code 3 if the test folder does not match an action name", function(ctx) {
                 assertExitCode(3);
                 assert(ctx.stderr.match(/error.*incorrect/i));
@@ -196,7 +196,7 @@ describe("test-worker command", function() {
                 assertMissingOrEmptyDirectory("build", "test-results");
             });
 
-        testCommand("test-projects/multiple-workers", "asset-compute:test-worker", ["-a", "doesNotExist"])
+        testCommand("test-projects/multiple-workers", "test-worker", ["-a", "doesNotExist"])
             .it("fails with exit code 3 if the action specified with -a does not exist", function(ctx) {
                 assertExitCode(3);
                 assert(ctx.stderr.match(/error.*doesNotExist/i));

--- a/test/commands/testutil.js
+++ b/test/commands/testutil.js
@@ -48,6 +48,10 @@ BaseCommand.prototype.runCommand = async (command, argv) => {
 function testCommand(dir, command, args=[]) {
     let prepareFn;
 
+    if (command.startsWith("asset-compute:")) {
+        command = command.substring("asset-compute:".length);
+    }
+
     const chain = oclifTest
         .stdout()
         .stderr()


### PR DESCRIPTION
For [NUI-561](https://jira.corp.adobe.com/browse/NUI-561).
    
- standalone cli name: `adobe-asset-compute`
- documented all 3 install options: aio, devDependency, global standalone
- also list with useful description in aio command list:
  "Develop and test Adobe Asset Compute workers"
- support `-h` in addition to `--help` in standalone mode

---

_Explaining the various options from the readme:_

This can be installed & used in three ways:

1. [aio plugin](#install-as-aio-plugin)
2. [local devDependency](#install-as-local-devdependency)
3. [global standalone cli](#install-as-global-standalone-cli)

### Install as aio plugin

This requires [aio-cli](https://github.com/adobe/aio-cli).

```
aio plugins:install @adobe/aio-cli-plugin-asset-compute
```

It provides the `asset-compute` command topic. You can run e.g. the test command using:

```
aio asset-compute test-worker
```

### Install as local devDependency

Install into your `devDependencies`:

```
npm install --save-dev @adobe/aio-cli-plugin-asset-compute
```

Then use in `npm` scripts in your `package.json`, for example for tests:

```json
   "scripts": {
       "test": "adobe-asset-compute test-worker"
   }
```

Use `npx` if you want to manually run it. Inside your project run for example:

```
npx adobe-asset-compute run-worker
```

### Install as global standalone cli

Install globally using:

```
npm install -g @adobe/aio-cli-plugin-asset-compute
```

This will add the `adobe-asset-compute` cli to your system. Run using:

```
adobe-asset-compute test-worker
```
