### PR TITLE
fix: in standalone cli mode we must run aio as child process for building actions

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -164,7 +164,7 @@
       "dependencies": {
         "dotenv": {
           "version": "8.2.0",
-          "resolved": "https://registry.npmjs.org/dotenv/-/dotenv-8.2.0.tgz",
+          "resolved": false,
           "integrity": "sha512-8sJ78ElpbDJBHNeBzUbUVLsqKdccaa/BXF1uPTw3GrvQTBgrQrtObr2mUrE38vzYd8cEv+m/JBfDLioYcfXoaw=="
         }
       }

--- a/package.json
+++ b/package.json
@@ -79,7 +79,7 @@
     "prepare": "oclif-dev manifest && oclif-dev readme",
     "version": "npm run prepare && git add README.md",
     "postpack": "rm -f oclif.manifest.json",
-    "test": "nyc mocha test/*/*.test.js",
+    "test": "nyc -r=text -r=lcov mocha test/*/*.test.js",
     "posttest": "eslint .",
     "report-coverage": "nyc report --reporter=text-lcov > coverage.lcov && codecov",
     "clean": "for d in test-projects/*; do pushd $d; rm -rf package-lock.json node_modules dist build .nui .asset-compute; popd; done",

--- a/src/base-command.js
+++ b/src/base-command.js
@@ -18,7 +18,8 @@ const yaml = require('js-yaml');
 const path = require('path');
 const ioruntime = require("@adobe/aio-cli-plugin-runtime");
 const debug = require('debug')('aio-asset-compute.base');
-const { spawnSync } = require("child_process");
+// imported like this so that we can overwrite child_process.spawnSync in unit tests
+const child_process = require("child_process");
 
 // converts action object from manifest.yml to openwhisk rest API json format
 function aioManifestToOpenwhiskAction(manifestAction) {
@@ -35,7 +36,7 @@ function aioManifestToOpenwhiskAction(manifestAction) {
 }
 
 async function execute(command, args) {
-    const result = spawnSync(command, args, {stdio: "inherit"});
+    const result = child_process.spawnSync(command, args, {stdio: "inherit"});
 
     if (result.error) {
         if (result.error.code === 'ENOENT') {

--- a/src/base-command.js
+++ b/src/base-command.js
@@ -48,13 +48,6 @@ async function execute(command, args) {
 
 class BaseCommand extends Command {
 
-    get pjson() {
-        if (!this._pjson) {
-            this._pjson = fs.readJSONSync('package.json');
-        }
-        return this._pjson;
-    }
-
     get manifest() {
         if (!this._manifest) {
             this._manifest = yaml.safeLoad(fs.readFileSync('manifest.yml', 'utf8'));
@@ -121,14 +114,6 @@ class BaseCommand extends Command {
         debug("aio manifest action:", manifestAction);
 
         return aioManifestToOpenwhiskAction(manifestAction);
-    }
-
-    get appName() {
-        return this.pjson.name;
-    }
-
-    get appVersion() {
-        return this.pjson.version;
     }
 
     get buildDir() {

--- a/src/commands/asset-compute/test-worker.js
+++ b/src/commands/asset-compute/test-worker.js
@@ -67,7 +67,7 @@ class TestWorkerCommand extends BaseCommand {
                 }
             }
         } catch (e) {
-            console.error("Error:", e.message);
+            console.error("\nError:", e.message);
             debug(e);
             process.exitCode = 3;
         }

--- a/test-projects/single-worker/.gitignore
+++ b/test-projects/single-worker/.gitignore
@@ -1,0 +1,1 @@
+rendition*

--- a/test/commands/run-worker.test.js
+++ b/test/commands/run-worker.test.js
@@ -17,6 +17,7 @@ const assert = require("assert");
 const fs = require("fs");
 const path = require("path");
 const rimraf = require("rimraf");
+const child_process = require("child_process");
 
 describe("run-worker command", function() {
 
@@ -154,6 +155,53 @@ describe("run-worker command", function() {
             .it("fails with exit code 1 if run on a project with multiple workers and no -a is set", function(ctx) {
                 assertExitCode(1);
                 assert(ctx.stderr.includes("Error: Must specify worker to run using --action"));
+
+                assert(!fs.existsSync("rendition.jpg"));
+                assert(!fs.existsSync(".nui"));
+                assertMissingOrEmptyDirectory("build", "run-worker");
+            });
+    });
+
+    describe("standalone mode", function() {
+        testCommand("test-projects/single-worker", "run-worker", ["test/asset-compute/worker/simple/file.jpg", "rendition.jpg"])
+            // ensure aio app deploy command is not available (empty object)
+            // so that it tries to do child process execution
+            .customCommands({
+                "app:deploy": false
+            })
+            .prepare((ctx) => {
+                // start with clean slate
+                if (fs.existsSync("rendition.jpg")) {
+                    fs.unlinkSync("rendition.jpg");
+                }
+
+                child_process._original_spawnSync = child_process.spawnSync;
+                child_process.spawnSync = function(cmd, args) {
+                    // track invocations for asserts below
+                    ctx.spawnSyncInvoked = ctx.spawnSyncInvoked || [];
+                    ctx.spawnSyncInvoked.push({
+                        cmd: cmd,
+                        args: args
+                    });
+
+                    // simulate failure
+                    return {
+                        error: {
+                            code: "ENOENT",
+                            message: "Did not find aio command"
+                        }
+                    };
+                };
+            })
+            .finally(() => {
+                child_process.spawnSync = child_process._original_spawnSync;
+            })
+            .it("invokes aio deploy as child process to build actions (and fail with exit code 1 if not found)", function(ctx) {
+                assertExitCode(1);
+
+                assert.equal(ctx.spawnSyncInvoked.length, 1);
+                assert.strictEqual(ctx.spawnSyncInvoked[0].cmd, "aio");
+                assert.deepEqual(ctx.spawnSyncInvoked[0].args, ["app:deploy", "--skip-deploy", "-a", "worker"]);
 
                 assert(!fs.existsSync("rendition.jpg"));
                 assert(!fs.existsSync(".nui"));

--- a/test/commands/testutil.js
+++ b/test/commands/testutil.js
@@ -33,8 +33,8 @@ const COMMANDS = {
 
 // tests are not running in a full oclif enviroment with the aio app plugin present,
 // so we have to include it as a dev dependency and manually load and run the commands
-// the code is invoking dynamically, by overwriting our BaseCommand.runCommand() helper
-BaseCommand.prototype.runCommand = async (command, argv) => {
+// the code is invoking dynamically, by overwriting our BaseCommand.runAioCommand() helper
+BaseCommand.prototype.runAioCommand = async (command, argv) => {
     if (COMMANDS[command]) {
         await require(COMMANDS[command]).run(argv);
     } else {

--- a/test/commands/testutil.js
+++ b/test/commands/testutil.js
@@ -14,8 +14,8 @@
 
 const MockServer = require("../../src/lib/mockserver");
 const WorkerTestRunner = require("../../src/lib/testrunner");
-const BaseCommand = require("../../src/base-command");
 
+const Config = require("@oclif/config");
 const { test: oclifTest } = require("@oclif/test");
 const stdmock = require("stdout-stderr");
 const path = require("path");
@@ -25,28 +25,51 @@ const assert = require("assert");
 const Docker = require("dockerode");
 const fs = require("fs");
 
+// to enable logging set this before the test:
+// process.env.TEST_OUTPUT = 1;
+
 const baseDir = process.cwd();
 
 const COMMANDS = {
     "app:deploy": "@adobe/aio-cli-plugin-app/src/commands/app/deploy"
 };
 
-// tests are not running in a full oclif enviroment with the aio app plugin present,
-// so we have to include it as a dev dependency and manually load and run the commands
-// the code is invoking dynamically, by overwriting our BaseCommand.runAioCommand() helper
-BaseCommand.prototype.runAioCommand = async (command, argv) => {
-    if (COMMANDS[command]) {
-        await require(COMMANDS[command]).run(argv);
-    } else {
-        throw new Error(`Missing test implementation of aio command ${command}`);
-    }
-};
+let CUSTOM_COMMANDS = {};
 
-// to enable logging set this before the test:
-// process.env.TEST_OUTPUT = 1;
+function patchOclifFindCommand() {
+    // tests are not running in a full oclif enviroment with the aio app plugin present,
+    // so we have to include it as a dev dependency and manually load and run the commands
+    // the code is invoking dynamically, by patching oclif Config.findCommand() function
+    // which we use in our base-command.js
+    const originalLoad = Config.load;
+    Config.load = async function(opts) {
+        const config = await originalLoad.call(this, opts);
+        const originalFindCommand = config.findCommand;
+        config.findCommand = function(id, opts) {
+            if (CUSTOM_COMMANDS[id]) {
+                if (typeof CUSTOM_COMMANDS[id] !== "string") {
+                    return null;
+                }
+
+                const cmd = require(CUSTOM_COMMANDS[id]);
+                return {
+                    load: function() {
+                        cmd.id = id;
+                        return cmd;
+                    }
+                };
+            } else {
+                return originalFindCommand.call(this, id, opts);
+            }
+        };
+        return config;
+    };
+}
+
+patchOclifFindCommand();
 
 function testCommand(dir, command, args=[]) {
-    let prepareFn;
+    let prepareFn, customCommands = COMMANDS;
 
     if (command.startsWith("asset-compute:")) {
         command = command.substring("asset-compute:".length);
@@ -64,12 +87,16 @@ function testCommand(dir, command, args=[]) {
             rimraf.sync("build");
 
             // install dependencies for the project
-            execSync("npm install");
+            if (!fs.existsSync("node_modules")) {
+                execSync("npm install");
+            }
         })
         .do(async ctx => {
             if (prepareFn) {
                 await prepareFn(ctx);
             }
+
+            CUSTOM_COMMANDS = customCommands;
         })
         // run the command to test
         .command([command, ...args])
@@ -95,6 +122,11 @@ function testCommand(dir, command, args=[]) {
 
     chain.prepare = function(fn) {
         prepareFn = fn;
+        return this;
+    };
+
+    chain.customCommands = function(cmds) {
+        customCommands = cmds;
         return this;
     };
 


### PR DESCRIPTION
Follow up from #17. Currently test-worker fails in projects generated with https://github.com/adobe/generator-aio-app/pull/55:

```
> aio app test

...

Actions:
- worker-example

Running tests in test/asset-compute/worker-example
Error: Building action failed, did not create /Users/alex/Work/code/nui/aio/temp/myworker/dist/actions/worker-example.zip
...
```

This fixes it by calling `aio app deploy` as child process. It still tries to find the command first, so that the aio plugin mode continues to work as before.