### PR TITLE
BUGFIX-RELEASE: NUI-628 - Any adobe-asset-compute plugin command fails with "aio not found" on Windows

### DIFF
--- a/src/base-command.js
+++ b/src/base-command.js
@@ -36,7 +36,8 @@ function aioManifestToOpenwhiskAction(manifestAction) {
 }
 
 async function execute(command, args) {
-    const result = child_process.spawnSync(command, args, {stdio: "inherit"});
+    // shell => required for Windows
+    const result = child_process.spawnSync(command, args, {shell: true, stdio: "inherit"});
 
     if (result.error) {
         if (result.error.code === 'ENOENT') {


### PR DESCRIPTION
Just adding the `shell` option to `spawnSync` fixed it.