### PR TITLE
fix semantic-release config to allow slashes / in commit messages

### DIFF
--- a/.releaserc.json
+++ b/.releaserc.json
@@ -8,16 +8,16 @@
           "release": false
         },
         {
-          "subject": "FEATURE-RELEASE:*",
+          "subject": "BREAKING-RELEASE:**",
+          "release": "major"
+        },
+        {
+          "subject": "FEATURE-RELEASE:**",
           "release": "minor"
         },
         {
-          "subject": "BUGFIX-RELEASE:*",
+          "subject": "BUGFIX-RELEASE:**",
           "release": "patch"
-        },
-        {
-          "subject": "BREAKING-RELEASE:*",
-          "release": "major"
         }
         ]
       }],


### PR DESCRIPTION
Test to see if `**` instead of `*` solves this issue: https://github.com/semantic-release/commit-analyzer/issues/175

semantic-release/commit-analyzer [uses](https://github.com/semantic-release/commit-analyzer/blob/master/lib/analyze-commit.js#L26) the [micromatch](https://www.npmjs.com/package/micromatch) which is indeed a file globbing library and would then not include `/` in `*` wildcards.

Also changed the order in the config to major > minor > patch.