### PR TITLE
semantic-release: back to single '*' as the previous fix did not work

### DIFF
--- a/.releaserc.json
+++ b/.releaserc.json
@@ -8,15 +8,15 @@
           "release": false
         },
         {
-          "subject": "BREAKING-RELEASE:**",
+          "subject": "BREAKING-RELEASE:*",
           "release": "major"
         },
         {
-          "subject": "FEATURE-RELEASE:**",
+          "subject": "FEATURE-RELEASE:*",
           "release": "minor"
         },
         {
-          "subject": "BUGFIX-RELEASE:**",
+          "subject": "BUGFIX-RELEASE:*",
           "release": "patch"
         }
         ]


### PR DESCRIPTION
Reverting #41. Will just try and release without a slash in the commit message to move on.