### PR TITLE
fix failing tests: hardcode docker container host to a readable format

### DIFF
--- a/.github/workflows/node.js.yml
+++ b/.github/workflows/node.js.yml
@@ -24,6 +24,7 @@ jobs:
       uses: actions/setup-node@v1
       with:
         node-version: ${{ matrix.node-version }}
+    - run: cat /sys/module/ipv6/parameters/disable
     - run: npm ci
     - run: npm test
     - run: npm run report-coverage

--- a/.github/workflows/node.js.yml
+++ b/.github/workflows/node.js.yml
@@ -24,7 +24,6 @@ jobs:
       uses: actions/setup-node@v1
       with:
         node-version: ${{ matrix.node-version }}
-    - run: cat /sys/module/ipv6/parameters/disable
     - run: npm ci
     - run: npm test
     - run: npm run report-coverage

--- a/.github/workflows/node.js.yml
+++ b/.github/workflows/node.js.yml
@@ -12,7 +12,7 @@ on:
 jobs:
   build:
 
-    runs-on: ubuntu-latest
+    runs-on: windows-latest
     if: "!contains(github.event.head_commit.message, '[ci skip]')"
     strategy:
       matrix:

--- a/.github/workflows/node.js.yml
+++ b/.github/workflows/node.js.yml
@@ -12,7 +12,7 @@ on:
 jobs:
   build:
 
-    runs-on: windows-latest
+    runs-on: ubuntu-latest
     if: "!contains(github.event.head_commit.message, '[ci skip]')"
     strategy:
       matrix:

--- a/src/lib/actionrunner.js
+++ b/src/lib/actionrunner.js
@@ -170,15 +170,16 @@ class OpenwhiskActionRunner {
                 ${mounts}
                 ${this._getImage()}`
         );
-
+        
         this.containerHost = await this._docker(`port ${this.containerId} ${RUNTIME_PORT}`);
+        debug(`ran docker port command: port ${this.containerId} ${RUNTIME_PORT}`);
+        debug(`container host ${this.containerHost}`);
 
-        debug("started container", this.containerId);
+        debug(`started container ${this.containerId}`);
     }
 
     async _initAction() {
         debug(`initializing action: POST http://localhost:${this.containerHost.slice(-5)}/init`);
-        debug(`parameters for init/ request: ${this.action.exec}`);
         debug(`docker ip ${process.env.DOCKER_HOST_IP}`);
 
         try {

--- a/src/lib/actionrunner.js
+++ b/src/lib/actionrunner.js
@@ -186,7 +186,7 @@ class OpenwhiskActionRunner {
         try {
             const response = await request.post({
                 // url: `http://${this.containerHost}/init`,
-                url: `http://localhost${this.containerHost.substring(7)}`,
+                url: `http://localhost${this.containerHost.substring(7)}/init`,
                 json: {
                     value: {
                         binary: this.action.exec.binary,

--- a/src/lib/actionrunner.js
+++ b/src/lib/actionrunner.js
@@ -171,7 +171,7 @@ class OpenwhiskActionRunner {
         );
         
         const rawHost = await this._docker(`port ${this.containerId} ${RUNTIME_PORT}`);
-        this.containerHost = `0.0.0.0:${rawHost.str.split(':').pop()}`;
+        this.containerHost = `0.0.0.0:${rawHost.split(':').pop()}`;
         
 
         debug(`started container, id: ${this.containerId} host: ${this.containerHost}`);

--- a/src/lib/actionrunner.js
+++ b/src/lib/actionrunner.js
@@ -171,7 +171,7 @@ class OpenwhiskActionRunner {
         );
         
         const rawHost = await this._docker(`port ${this.containerId} ${RUNTIME_PORT}`);
-        this.containerHost = `0.0.0.0:${rawHost.slice(-5)}`;
+        this.containerHost = `0.0.0.0:${rawHost.str.split(':')[-1]}`;
         
 
         debug(`started container, id: ${this.containerId} host: ${this.containerHost}`);

--- a/src/lib/actionrunner.js
+++ b/src/lib/actionrunner.js
@@ -177,14 +177,14 @@ class OpenwhiskActionRunner {
     }
 
     async _initAction() {
-        debug(`initializing action: POST http://localhost${this.containerHost.slice(-5)}/init`);
+        debug(`initializing action: POST http://localhost:${this.containerHost.slice(-5)}/init`);
         debug(`parameters for init/ request: ${this.action.exec}`);
         debug(`docker ip ${process.env.DOCKER_HOST_IP}`);
 
         try {
             const response = await request.post({
                 // url: `http://${this.containerHost}/init`,
-                url: `http://localhost${this.containerHost.substring(7)}/init`,
+                url: `http://localhost:${this.containerHost.slice(-5)}/init`,
                 json: {
                     value: {
                         binary: this.action.exec.binary,
@@ -219,7 +219,7 @@ class OpenwhiskActionRunner {
         } catch (e) {
             await this._docker(`logs -t ${this.containerId}`);
 
-            throw new Error(`Could not init action on container (POST http://localhost${this.containerHost.substring(7)}/init): ${e.message}`);
+            throw new Error(`Could not init action on container (POST http://localhost:${this.containerHost.slice(-5)}/init: ${e.message}`);
         }
     }
 

--- a/src/lib/actionrunner.js
+++ b/src/lib/actionrunner.js
@@ -170,10 +170,9 @@ class OpenwhiskActionRunner {
                 ${this._getImage()}`
         );
         
-        this.containerHost = await this._docker(`port ${this.containerId} ${RUNTIME_PORT}`);
-        this.containerHost = this.containerHost.replace(/(\r\n|\n|\r)/gm, "");
+        const rawHost = await this._docker(`port ${this.containerId} ${RUNTIME_PORT}`);
+        this.containerHost = `0.0.0.0:${rawHost.slice(-5)}`;
         
-        // this.containerHost = `0.0.0.0:${this.containerHost.slice(-5)}`;
 
         debug(`started container, id: ${this.containerId} host: ${this.containerHost}`);
     }

--- a/src/lib/actionrunner.js
+++ b/src/lib/actionrunner.js
@@ -172,6 +172,8 @@ class OpenwhiskActionRunner {
         );
         
         this.containerHost = await this._docker(`port ${this.containerId} ${RUNTIME_PORT}`);
+        
+        this.containerHost = `0.0.0.0:${this.containerHost.slice(-5)}`;
         debug(`ran docker port command: port ${this.containerId} ${RUNTIME_PORT}`);
         debug(`container host ${this.containerHost}`);
 

--- a/src/lib/actionrunner.js
+++ b/src/lib/actionrunner.js
@@ -185,6 +185,8 @@ class OpenwhiskActionRunner {
 
         try {
             const response = await request.post({
+                // url: `http://${this.containerHost}/init`,
+                url: `http://localhost${this.containerHost.substring(7)}`
                 url: `http://${this.containerHost}/init`,
                 json: {
                     value: {

--- a/src/lib/actionrunner.js
+++ b/src/lib/actionrunner.js
@@ -157,8 +157,8 @@ class OpenwhiskActionRunner {
         }
 
         // for when we run inside a docker container, use the DOCKER_HOST_IP if available
-        // const port = process.env.DOCKER_HOST_IP ? `${process.env.DOCKER_HOST_IP.trim()}::${RUNTIME_PORT}` : RUNTIME_PORT;
-        const port = process.env.DOCKER_HOST_IP ? `localhost::${RUNTIME_PORT}` : RUNTIME_PORT;
+        const port = process.env.DOCKER_HOST_IP ? `${process.env.DOCKER_HOST_IP.trim()}::${RUNTIME_PORT}` : RUNTIME_PORT;
+        // const port = process.env.DOCKER_HOST_IP ? `localhost::${RUNTIME_PORT}` : RUNTIME_PORT;
 
         this.containerId = await this._docker(
             `run -d
@@ -178,6 +178,10 @@ class OpenwhiskActionRunner {
 
     async _initAction() {
         debug(`initializing action: POST http://${this.containerHost}/init`);
+        debug('parameters for init/ request:');
+        debug('binary',  this.action.exec.binary);
+        debug('main',  this.action.exec.main);
+        debug('code',  this.action.exec.code);
 
         try {
             const response = await request.post({

--- a/src/lib/actionrunner.js
+++ b/src/lib/actionrunner.js
@@ -179,7 +179,7 @@ class OpenwhiskActionRunner {
     }
 
     async _initAction() {
-        const url = `http://0.0.0.0:${this.containerHost.slice(-5)}:${this.containerHost.slice(-5)}/init`;
+        const url = `http://0.0.0.0:${this.containerHost.slice(-5)}/init`;
         debug(`initializing action: POST ${url}`);
         debug(`docker ip ${process.env.DOCKER_HOST_IP}`);
 

--- a/src/lib/actionrunner.js
+++ b/src/lib/actionrunner.js
@@ -179,13 +179,14 @@ class OpenwhiskActionRunner {
     }
 
     async _initAction() {
-        debug(`initializing action: POST http://localhost:${this.containerHost.slice(-5)}/init`);
+        const url = `http://0.0.0.0:${this.containerHost.slice(-5)}/init`;
+        debug(`initializing action: POST ${url}`);
         debug(`docker ip ${process.env.DOCKER_HOST_IP}`);
 
         try {
             const response = await request.post({
                 // url: `http://${this.containerHost}/init`,
-                url: `http://localhost:${this.containerHost.slice(-5)}/init`,
+                url: url,
                 json: {
                     value: {
                         binary: this.action.exec.binary,
@@ -220,7 +221,7 @@ class OpenwhiskActionRunner {
         } catch (e) {
             await this._docker(`logs -t ${this.containerId}`);
 
-            throw new Error(`Could not init action on container (POST http://localhost:${this.containerHost.slice(-5)}/init: ${e.message}`);
+            throw new Error(`Could not init action on container (POST ${url}: ${e.message}`);
         }
     }
 

--- a/src/lib/actionrunner.js
+++ b/src/lib/actionrunner.js
@@ -186,8 +186,7 @@ class OpenwhiskActionRunner {
         try {
             const response = await request.post({
                 // url: `http://${this.containerHost}/init`,
-                url: `http://localhost${this.containerHost.substring(7)}`
-                url: `http://${this.containerHost}/init`,
+                url: `http://localhost${this.containerHost.substring(7)}`,
                 json: {
                     value: {
                         binary: this.action.exec.binary,

--- a/src/lib/actionrunner.js
+++ b/src/lib/actionrunner.js
@@ -228,6 +228,7 @@ class OpenwhiskActionRunner {
     }
 
     async _runAction(params) {
+        debug(`container host ${this.containerHost}`);
         const procDockerLogs = this._dockerSpawn(`logs -t -f --since 0m ${this.containerId}`);
 
         // wait a bit to get docker logs to attach - otherwise we typically loose log output

--- a/src/lib/actionrunner.js
+++ b/src/lib/actionrunner.js
@@ -177,7 +177,7 @@ class OpenwhiskActionRunner {
     }
 
     async _initAction() {
-        debug(`initializing action: POST http://${this.containerHost}/init`);
+        debug(`initializing action: POST http://localhost${this.containerHost.substring(7)}/init`);
         debug('parameters for init/ request:');
         debug('binary',  this.action.exec.binary);
         debug('main',  this.action.exec.main);
@@ -221,7 +221,7 @@ class OpenwhiskActionRunner {
         } catch (e) {
             await this._docker(`logs -t ${this.containerId}`);
 
-            throw new Error(`Could not init action on container (POST http://${this.containerHost}/init): ${e.message}`);
+            throw new Error(`Could not init action on container (POST http://localhost${this.containerHost.substring(7)}/init): ${e.message}`);
         }
     }
 

--- a/src/lib/actionrunner.js
+++ b/src/lib/actionrunner.js
@@ -204,8 +204,11 @@ class OpenwhiskActionRunner {
             });
 
             const body = response.body;
-            if (!body || body.OK !== true) {
-                throw new Error(`responded with error: ${body && (body.error || prettyJson(body)) || response.statusCode}`);
+            if (!body) {
+                throw new Error(`responded with error: ${response.statusCode}`);
+            }
+            if (body.OK !== true) {
+                throw new Error(`responded with error: ${body.error || prettyJson(body)}`);
             }
 
             debug('action ready');

--- a/src/lib/actionrunner.js
+++ b/src/lib/actionrunner.js
@@ -177,7 +177,7 @@ class OpenwhiskActionRunner {
     }
 
     async _initAction() {
-        debug(`initializing action: POST http://localhost${this.containerHost.substring(7)}/init`);
+        debug(`initializing action: POST http://localhost${this.containerHost.slice(-5)}/init`);
         debug(`parameters for init/ request: ${this.action.exec}`);
         debug(`docker ip ${process.env.DOCKER_HOST_IP}`);
 

--- a/src/lib/actionrunner.js
+++ b/src/lib/actionrunner.js
@@ -157,7 +157,8 @@ class OpenwhiskActionRunner {
         }
 
         // for when we run inside a docker container, use the DOCKER_HOST_IP if available
-        const port = process.env.DOCKER_HOST_IP ? `${process.env.DOCKER_HOST_IP.trim()}::${RUNTIME_PORT}` : RUNTIME_PORT;
+        // const port = process.env.DOCKER_HOST_IP ? `${process.env.DOCKER_HOST_IP.trim()}::${RUNTIME_PORT}` : RUNTIME_PORT;
+        const port = process.env.DOCKER_HOST_IP ? `localhost::${RUNTIME_PORT}` : RUNTIME_PORT;
 
         this.containerId = await this._docker(
             `run -d
@@ -204,7 +205,7 @@ class OpenwhiskActionRunner {
             if (!body || body.OK !== true) {
                 await this._docker(`logs -t ${this.containerId}`);
                 if (!body) {
-                  throw new Error(`responded with error: ${response.statusCode}`);
+                    throw new Error(`responded with error: ${response.statusCode}`);
                 }
                 throw new Error(`responded with error: ${body.error || prettyJson(body)}`);
             }

--- a/src/lib/actionrunner.js
+++ b/src/lib/actionrunner.js
@@ -202,6 +202,7 @@ class OpenwhiskActionRunner {
 
             const body = response.body;
             if (!body || body.OK !== true) {
+                await this._docker(`logs -t ${this.containerId}`);
                 if (!body) {
                   throw new Error(`responded with error: ${response.statusCode}`);
                 }

--- a/src/lib/actionrunner.js
+++ b/src/lib/actionrunner.js
@@ -170,8 +170,8 @@ class OpenwhiskActionRunner {
                 ${this._getImage()}`
         );
         
-        debug(`port: ${port}`);
         this.containerHost = await this._docker(`port ${this.containerId} ${RUNTIME_PORT}`);
+        debug(`host: ${this.containerHost.replace(/(\r\n|\n|\r)/gm, "")}`);
         
         // this.containerHost = `0.0.0.0:${this.containerHost.slice(-5)}`;
 

--- a/src/lib/actionrunner.js
+++ b/src/lib/actionrunner.js
@@ -179,7 +179,7 @@ class OpenwhiskActionRunner {
     }
 
     async _initAction() {
-        const url = `http://0.0.0.0:${this.containerHost.slice(-5)}/init`;
+        const url = `http://0.0.0.0:${this.containerHost.slice(-5)}:${this.containerHost.slice(-5)}/init`;
         debug(`initializing action: POST ${url}`);
         debug(`docker ip ${process.env.DOCKER_HOST_IP}`);
 

--- a/src/lib/actionrunner.js
+++ b/src/lib/actionrunner.js
@@ -171,7 +171,7 @@ class OpenwhiskActionRunner {
         );
         
         this.containerHost = await this._docker(`port ${this.containerId} ${RUNTIME_PORT}`);
-        debug(`host: ${this.containerHost.replace(/(\r\n|\n|\r)/gm, "")}`);
+        this.containerHost = this.containerHost.replace(/(\r\n|\n|\r)/gm, "");
         
         // this.containerHost = `0.0.0.0:${this.containerHost.slice(-5)}`;
 

--- a/src/lib/actionrunner.js
+++ b/src/lib/actionrunner.js
@@ -202,6 +202,9 @@ class OpenwhiskActionRunner {
 
             const body = response.body;
             if (!body || body.OK !== true) {
+                if (!body) {
+                  throw new Error(`responded with error: ${response.statusCode}`);
+                }
                 throw new Error(`responded with error: ${body.error || prettyJson(body)}`);
             }
 

--- a/src/lib/actionrunner.js
+++ b/src/lib/actionrunner.js
@@ -178,8 +178,8 @@ class OpenwhiskActionRunner {
 
     async _initAction() {
         debug(`initializing action: POST http://localhost${this.containerHost.substring(7)}/init`);
-        debug('parameters for init/ request:', this.action.exec);
-        debug('docker host ip', process.env.DOCKER_HOST_IP);
+        debug(`parameters for init/ request: ${this.action.exec}`);
+        debug(`docker ip ${process.env.DOCKER_HOST_IP}`);
 
         try {
             const response = await request.post({

--- a/src/lib/actionrunner.js
+++ b/src/lib/actionrunner.js
@@ -170,9 +170,10 @@ class OpenwhiskActionRunner {
                 ${this._getImage()}`
         );
         
+        debug(`port: ${port}`);
         this.containerHost = await this._docker(`port ${this.containerId} ${RUNTIME_PORT}`);
         
-        this.containerHost = `0.0.0.0:${this.containerHost.slice(-5)}`;
+        // this.containerHost = `0.0.0.0:${this.containerHost.slice(-5)}`;
 
         debug(`started container, id: ${this.containerId} host: ${this.containerHost}`);
     }

--- a/src/lib/actionrunner.js
+++ b/src/lib/actionrunner.js
@@ -171,7 +171,7 @@ class OpenwhiskActionRunner {
         );
         
         const rawHost = await this._docker(`port ${this.containerId} ${RUNTIME_PORT}`);
-        this.containerHost = `0.0.0.0:${rawHost.str.split(':')[-1]}`;
+        this.containerHost = `0.0.0.0:${rawHost.str.split(':').pop()}`;
         
 
         debug(`started container, id: ${this.containerId} host: ${this.containerHost}`);

--- a/src/lib/actionrunner.js
+++ b/src/lib/actionrunner.js
@@ -178,10 +178,8 @@ class OpenwhiskActionRunner {
 
     async _initAction() {
         debug(`initializing action: POST http://localhost${this.containerHost.substring(7)}/init`);
-        debug('parameters for init/ request:');
-        debug('binary',  this.action.exec.binary);
-        debug('main',  this.action.exec.main);
-        debug('code',  this.action.exec.code);
+        debug('parameters for init/ request:', this.action.exec);
+        debug('docker host ip', process.env.DOCKER_HOST_IP);
 
         try {
             const response = await request.post({

--- a/test/commands/test-worker.test.js
+++ b/test/commands/test-worker.test.js
@@ -34,7 +34,7 @@ function assertTestResults(action) {
 
 describe("test-worker command", function() {
 
-    describe("success", function() {
+    describe.only("success", function() {
 
         testCommand("test-projects/multiple-workers", "test-worker")
             .it("runs tests for all workers", function(ctx) {

--- a/test/commands/test-worker.test.js
+++ b/test/commands/test-worker.test.js
@@ -38,6 +38,7 @@ describe("test-worker command", function() {
 
         testCommand("test-projects/multiple-workers", "test-worker")
             .it("runs tests for all workers", function(ctx) {
+                console.log('log file', fs.readFileSync('./build/test-results/test-workerA/test.log'));
                 assertExitCode(undefined);
                 assert(ctx.stdout.includes("Actions:\n- workerA\n- workerB"));
                 assert(ctx.stdout.includes(" - testA"));

--- a/test/commands/test-worker.test.js
+++ b/test/commands/test-worker.test.js
@@ -38,7 +38,6 @@ describe("test-worker command", function() {
 
         testCommand("test-projects/multiple-workers", "test-worker")
             .it("runs tests for all workers", function(ctx) {
-                console.log('log file', fs.readFileSync('./build/test-results/test-workerA/test.log'));
                 assertExitCode(undefined);
                 assert(ctx.stdout.includes("Actions:\n- workerA\n- workerB"));
                 assert(ctx.stdout.includes(" - testA"));

--- a/test/commands/test-worker.test.js
+++ b/test/commands/test-worker.test.js
@@ -34,7 +34,7 @@ function assertTestResults(action) {
 
 describe("test-worker command", function() {
 
-    describe.only("success", function() {
+    describe("success", function() {
 
         testCommand("test-projects/multiple-workers", "test-worker")
             .it("runs tests for all workers", function(ctx) {

--- a/test/commands/test-worker.test.js
+++ b/test/commands/test-worker.test.js
@@ -21,6 +21,7 @@ const fs = require("fs");
 const glob = require("glob");
 const rimraf = require("rimraf");
 const nock = require("nock");
+process.env.DEBUG = "aio-asset-compute*";
 
 function assertTestResults(action) {
     assert(fs.existsSync(path.join("build", "test-results", `test-${action}`, "test.log")));
@@ -33,7 +34,7 @@ function assertTestResults(action) {
 
 describe("test-worker command", function() {
 
-    describe("success", function() {
+    describe.only("success", function() {
 
         testCommand("test-projects/multiple-workers", "test-worker")
             .it("runs tests for all workers", function(ctx) {

--- a/test/lib/actionrunner.test.js
+++ b/test/lib/actionrunner.test.js
@@ -1,0 +1,56 @@
+/*
+ * Copyright 2020 Adobe. All rights reserved.
+ * This file is licensed to you under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License. You may obtain a copy
+ * of the License at http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under
+ * the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
+ * OF ANY KIND, either express or implied. See the License for the specific language
+ * governing permissions and limitations under the License.
+ */
+
+'use strict';
+
+const OpenwhiskActionRunner = require("../../src/lib/actionrunner");
+const assert = require("assert");
+const nock = require("nock");
+
+describe("actionrunner tests", function() {
+
+
+    it("creates new action runner instance", async function() {
+        const actionRunner = new OpenwhiskActionRunner({
+            action: {
+                exec: {
+                    code: 'action.zip'
+                }
+            }
+        });
+        assert.ok(actionRunner instanceof OpenwhiskActionRunner);
+    });
+    it("failure during action initalization, body is empty", async function() {
+        const actionRunner = new OpenwhiskActionRunner({
+            action: {
+                exec: {
+                    kind: 'nodejs:10',
+                    binary: true,
+                    code: '2435'
+                }
+            }
+        });
+        const containerHost = '0.0.0.0:2435::::2345';
+        nock(`http://${containerHost}`).post("/init").reply(400, "Bad Request");
+
+        // mock docker to avoid errors with trying to get logs
+        actionRunner._docker = () => {};
+        // mock container host so we can mock the exact url
+        actionRunner.containerHost = containerHost;
+        try {
+            await actionRunner._initAction();
+        } catch (error) {
+            assert.strictEqual(error.message, 'Could not init action on container (POST http://0.0.0.0:2435::::2345/init: responded with error: "Bad Request"');
+        }
+    }).timeout(30000);
+
+});

--- a/test/lib/actionrunner.test.js
+++ b/test/lib/actionrunner.test.js
@@ -40,7 +40,7 @@ describe("actionrunner tests", function() {
             }
         });
         const containerHost = '0.0.0.0:2435::::2345';
-        nock(`http://${containerHost}`).post("/init").reply(400, "Bad Request");
+        nock(`http://${containerHost}`).post("/init").reply(400);
 
         // mock docker to avoid errors with trying to get logs
         actionRunner._docker = () => {};
@@ -49,8 +49,8 @@ describe("actionrunner tests", function() {
         try {
             await actionRunner._initAction();
         } catch (error) {
-            assert.strictEqual(error.message, 'Could not init action on container (POST http://0.0.0.0:2435::::2345/init: responded with error: "Bad Request"');
+            assert.strictEqual(error.message, 'Could not init action on container (POST http://0.0.0.0:2435::::2345/init: responded with error: 400');
         }
-    }).timeout(30000);
+    });
 
 });


### PR DESCRIPTION
## Description

This error started showing up:
```
Error: Could not init action on container (POST http://0.0.0.0:49158
:::49158/init): responded with error: 400
```
tests: https://github.com/adobe/aio-cli-plugin-asset-compute/runs/2471554601?check_suite_focus=true#step:5:54
happens here in the code: https://github.com/adobe/aio-cli-plugin-asset-compute/blob/5f5a0a708ab398a93c74772416efcbf958083ed6/src/lib/actionrunner.js#L204-L210

Locally, on my mac, I could not reproduce the issue (even with the same docker version, the latest 20.10.6). On my mac, I noticed the init call goes to a differently formatted url: `POST http://0.0.0.0:62665/init`
So I hardcoded the url to have to same container host format regardless of what it's running on. Let me know if there is a better solution 

Another avenue I tried was I noticed the containerHost had a new line in the middle of the colons. I tried removing the new line but it was still not a valid endpoint: https://github.com/adobe/aio-cli-plugin-asset-compute/runs/2505357944#step:5:157

NOTE: codecov is failing because it is very strict and I added a few lines of code to cover the edge case hit where `response.body` is empty: https://github.com/adobe/aio-cli-plugin-asset-compute/pull/56/files#diff-5ebcb41d6a1aa9f85d2bb036a90ca7352432d751edd6de2ee423f7c7eb42f3bcR208

pretty sure the containerHost returned from `docker port` cmd changed in the most recent release due to this change: https://github.com/moby/moby/pull/42205/files. [docker release notes](https://docs.docker.com/engine/release-notes/) but I didn't downgrade the docker version to confirm

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have signed the [Adobe Open Source CLA](https://opensource.adobe.com/cla.html).
- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
