### PR TITLE
enable sizewatcher to post comments to PR

### DIFF
--- a/.github/workflows/node.js.yml
+++ b/.github/workflows/node.js.yml
@@ -34,6 +34,9 @@ jobs:
     steps:
     - uses: actions/checkout@v2
     - run: npx @adobe/sizewatcher
+      env:
+        GITHUB_TOKEN: ${{ secrets.ADOBE_BOT_GITHUB_TOKEN }}
+
   semantic-release:
     runs-on: ubuntu-latest
     needs: [build]


### PR DESCRIPTION
Needs the right env var with the github API token passed in.
