### PR TITLE
ASSETS-9773 prepareInOutDir precreate errors directory

### DIFF
--- a/src/lib/util.js
+++ b/src/lib/util.js
@@ -78,9 +78,6 @@ module.exports = {
             return;
         }
         fse.removeSync(dirs.in);
-        if (dirExistsAndEmpty(dirs.errors)) {
-            fse.removeSync(dirs.errors);
-        }
         fse.removeSync(dirs.out);
         fse.removeSync(dirs.mock_crt);
         if (dirExistsAndEmpty(dirs.failed)) {

--- a/src/lib/util.js
+++ b/src/lib/util.js
@@ -49,6 +49,7 @@ module.exports = {
             work:     path.resolve(buildDir, uniqueName),
             in:       path.resolve(buildDir, uniqueName, 'in'),
             out:      path.resolve(buildDir, uniqueName, 'out'),
+            errors:   path.resolve(buildDir, uniqueName, 'out', 'errors'),
             failed:   path.resolve(buildDir, uniqueName, 'failed'),
             mock_crt: path.resolve(buildDir, uniqueName, 'mock-crt')
         };
@@ -58,6 +59,9 @@ module.exports = {
         fse.ensureDirSync(dirs.out);
         // ensure writeable by mounted docker container by giving everyone read+write
         fse.chmodSync(dirs.out, 0o777);
+        // pre-create nested out/errors directory for reliable access to shellscript worker error.json and type.txt files
+        fse.ensureDirSync(dirs.errors);
+        fse.chmodSync(dirs.errors, 0o777);
         fse.ensureDirSync(dirs.failed);
         // ensure writeable by mounted docker container by giving everyone read+write
         fse.chmodSync(dirs.failed, 0o777);
@@ -74,6 +78,9 @@ module.exports = {
             return;
         }
         fse.removeSync(dirs.in);
+        if (dirExistsAndEmpty(dirs.errors)) {
+            fse.removeSync(dirs.errors);
+        }
         fse.removeSync(dirs.out);
         fse.removeSync(dirs.mock_crt);
         if (dirExistsAndEmpty(dirs.failed)) {


### PR DESCRIPTION
## Description

This change makes the Util.prepareInOutDir() function pre-create the `out/errors` directory used by ShellScriptWorker with mode 777 to better support CI when the docker daemon is running under a different user than the plugin process.

## Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
