### PR TITLE
ASSETS-9773 recreate out/errors after rimraf of parent out dir

### DIFF
--- a/src/lib/util.js
+++ b/src/lib/util.js
@@ -96,6 +96,9 @@ module.exports = {
     emptyInOutDir: function (dirs) {
         rimraf.sync(`${dirs.in}/*`);
         rimraf.sync(`${dirs.out}/*`);
+        // re-create nested out/errors directory after rimraf-ing its parent dir
+        fse.ensureDirSync(dirs.errors);
+        fse.chmodSync(dirs.errors, 0o777);
     },
 
     extension: function (file) {


### PR DESCRIPTION
## Description

Fixes ASSETS-9773 for cases of multiple tests run against the same worker container. 

Revisits issue from PR #79 after manual testing revealed that the original fix worked for the first test, but then the same issue appeared again on the second test.


## Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
